### PR TITLE
[HOTFIX]:채널 동영상 조회시 커서기반 서비스를 호출하지 않는 문제 해결

### DIFF
--- a/src/main/java/channeling/be/domain/channel/presentation/ChannelController.java
+++ b/src/main/java/channeling/be/domain/channel/presentation/ChannelController.java
@@ -55,7 +55,7 @@ public class ChannelController {
     @RequestParam(value = "cursor",required = false) LocalDateTime cursor,
     @RequestParam(value = "size", defaultValue = "8") int size) {
     channelService.validateChannelByIdAndMember(channelId);
-    Slice<VideoResDTO.VideoBrief> videoBriefSlice = videoService.getChannelVideoListByType(channelId,type,page, size);
+    Slice<VideoResDTO.VideoBrief> videoBriefSlice = videoService.getChannelVideoListByTypeAfterCursor(channelId,type,cursor, size);
     return ApiResponse.onSuccess(ChannelConverter.toChannelVideoList(channelId, videoBriefSlice));
   }
 


### PR DESCRIPTION
## PR 제목
[HOTFIX]:채널 동영상 조회시 커서기반 서비스를 호출하지 않는 문제 해결

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
#23 이슈에서 컨플릭트난 부분 해결했을때
기존 페이징 기반 서비스 메소드를 호출하는 것으로 잘못 머지함 -> 커서기반으로 변경

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#23 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.