### PR TITLE
[FEAT]: 자체 인증 구현 (Spring Security, JWT, Redis)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,14 @@ dependencies {
 
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // JWT
+    implementation 'com.auth0:java-jwt:4.5.0'
+    implementation 'com.auth0:jwks-rsa:0.20.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 def querydslDir = "src/main/generated"

--- a/src/main/java/channeling/be/domain/auth/annotation/LoginMember.java
+++ b/src/main/java/channeling/be/domain/auth/annotation/LoginMember.java
@@ -1,0 +1,11 @@
+package channeling.be.domain.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/channeling/be/domain/auth/annotation/LoginMemberArgumentResolver.java
+++ b/src/main/java/channeling/be/domain/auth/annotation/LoginMemberArgumentResolver.java
@@ -1,0 +1,35 @@
+package channeling.be.domain.auth.annotation;
+
+import channeling.be.domain.auth.domain.CustomUserDetails;
+import channeling.be.domain.member.domain.Member;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(LoginMember.class) && parameter.getParameterType().equals(Member.class);
+        }
+
+        @Override
+        public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (authentication == null|| authentication.getPrincipal().equals("anonymousUser")) {
+                throw new BadCredentialsException("로그인 정보가 없습니다.");
+            }
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            return userDetails.getMember();
+        }
+}

--- a/src/main/java/channeling/be/domain/auth/application/CustomUserDetailsService.java
+++ b/src/main/java/channeling/be/domain/auth/application/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package channeling.be.domain.auth.application;
+
+import channeling.be.domain.auth.domain.CustomUserDetails;
+import channeling.be.domain.member.domain.Member;
+import channeling.be.domain.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String googleId) throws UsernameNotFoundException {
+        Member member = memberRepository.findByGoogleId(googleId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with googleId: " + googleId ));
+        return new CustomUserDetails(member);
+    }
+}
+

--- a/src/main/java/channeling/be/domain/auth/application/MemberOauth2UserService.java
+++ b/src/main/java/channeling/be/domain/auth/application/MemberOauth2UserService.java
@@ -30,7 +30,7 @@ public class MemberOauth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         // TODO [지우기] 인증 사용자 정보 샘플
         System.out.println(" 엑세스 토큰 " + userRequest.getAccessToken().getTokenValue());
-        System.out.println(" 유저 정보 샘플 " + memberAttribute.get("name"));
+        System.out.println(" 유저 정보 샘플 " + memberAttribute);
 
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),

--- a/src/main/java/channeling/be/domain/auth/domain/CustomUserDetails.java
+++ b/src/main/java/channeling/be/domain/auth/domain/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package channeling.be.domain.auth.domain;
+
+import channeling.be.domain.member.domain.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 역할(권한)을 사용하지 않는다면 빈 리스트 반환
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getGoogleId();  // 또는 memberId 등
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;  // 필요 시 구현
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;  // 필요 시 구현
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;  // 필요 시 구현
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;  // 필요 시 구현
+    }
+
+    public Member getMember() {
+        return member;
+    }
+}
+

--- a/src/main/java/channeling/be/domain/auth/filter/AuthenticationEntryPointImpl.java
+++ b/src/main/java/channeling/be/domain/auth/filter/AuthenticationEntryPointImpl.java
@@ -1,0 +1,42 @@
+package channeling.be.domain.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *  로그인 요청을 제외한 다른 요청에서 헤더에 토큰이 없거나,
+ * 토큰이 만료되거나, 잘못되었을 때 어떻게 할지 정하는 클래스
+ */
+@Slf4j
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        log.info(("Commerce 실행"));
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 상태 코드
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("status", HttpServletResponse.SC_UNAUTHORIZED);
+        responseBody.put("error", "Unauthorized");
+        responseBody.put("message", authException.getMessage());
+        responseBody.put("path", request.getRequestURI());
+
+        String json = objectMapper.writeValueAsString(responseBody);
+        response.getWriter().write(json);
+
+
+    }
+}
+
+

--- a/src/main/java/channeling/be/domain/auth/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/channeling/be/domain/auth/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,74 @@
+package channeling.be.domain.auth.filter;
+
+import channeling.be.domain.auth.application.CustomUserDetailsService;
+import channeling.be.global.infrastructure.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+
+/**
+ * JWT 인증용 커스텀 필터.
+ * - 요청당 한 번(OncePerRequestFilter) 실행된다.
+ * - Access Token 검증 → Google ID 추출 → DB 조회 → 인증 객체 생성 과정을 거쳐
+ *   SecurityContext에 인증 정보를 저장한다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    /**
+     * 매 요청마다 실행되는 진입점.
+     * 토큰을 검증·인증하고, 다음 필터로 체인을 이어준다.
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("jwt 토큰 인증 시작");
+        checkAccessTokenAndAuthentication(request, response, filterChain);
+
+
+
+    }
+
+    /**
+     * ① 요청 헤더에서 토큰 추출
+     * ② 토큰 유효성·블랙리스트 여부 검사
+     * ③ 토큰에서 Google ID 추출
+     * ④ Google ID로 DB 조회하여 UserDetails 확보
+     * ⑤ 인증 정보(SecurityContext) 저장
+     */
+    private void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        jwtUtil.extractAccessToken(request)
+                .filter(jwtUtil::isTokenValid) // 토큰을 검증
+                .filter(accessToken -> !jwtUtil.isTokenInBlackList(accessToken)) // 블랙리스틑 여부 판단
+                .flatMap(jwtUtil::extractGoogleId) // 토큰에서 구글 아이디 추출
+                .map(customUserDetailsService::loadUserByUsername) // db 에서 존재하는 지 확인
+                .ifPresent(this::saveAuthentication); // -> 통과하면 로그인 성공! -> 세션에 로그인 멤버 저장
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 인증 객체를 SecurityContextHolder에 저장한다.
+     * @param userDetails 인증에 성공한 사용자 정보
+     */
+    private void saveAuthentication(UserDetails userDetails) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, Collections.emptyList());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+    }
+}

--- a/src/main/java/channeling/be/domain/auth/handler/Oauth2LoginSuccessHandler.java
+++ b/src/main/java/channeling/be/domain/auth/handler/Oauth2LoginSuccessHandler.java
@@ -1,13 +1,17 @@
 package channeling.be.domain.auth.handler;
 
+import channeling.be.domain.member.domain.Member;
+import channeling.be.domain.member.domain.repository.MemberRepository;
+import channeling.be.global.infrastructure.jwt.JwtUtil;
+import channeling.be.global.infrastructure.redis.RedisUtil;
 import channeling.be.response.exception.handler.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -16,37 +20,68 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
+
+
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class Oauth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final ObjectMapper om;
     private final OAuth2AuthorizedClientService authorizedClientService;
+    private final JwtUtil jwtUtil;    // JWT 토큰 생성기
+    private final RedisUtil redisUtil;
+    private final MemberRepository memberRepository;
 
     // 로그인 성공 시 처리하는 메서드
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-        // TODO [지우기] 인증 사용자 정보 샘플
-        System.out.println("로그인 성공 " + authentication.getName());
-        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-        System.out.println("사용자 정보 " + oAuth2User.getAttributes().get("name"));
+        log.info("로그인 성공 후, 헨들러 진입");
+        // TODO [지우기] 인증 사용자 정보 샘플 -> 이거는 로그로 남겨둬야할듯..?
+        /* -------------------------------------------------
+         * 구글 accesstoken 꺼내기
+         * ------------------------------------------------- */
+        OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
+        String googleAccessToken = authorizedClientService
+                .loadAuthorizedClient(
+                        oauthToken.getAuthorizedClientRegistrationId(), // "google"
+                        oauthToken.getName())                           // 현재 사용자 식별자
+                .getAccessToken()
+                .getTokenValue();
 
+        log.info("컨텍스트에서 구글 엑세스 토큰 추출 = {}" , googleAccessToken);
+        /* -------------------------------------------------
+         * OAuth2User 꺼내기
+         * ------------------------------------------------- */
+        OAuth2User oauthUser  = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attrs = oauthUser.getAttributes(); // 멤버 속성
+        log.info("컨텍스트에서 토큰 내의 회원 정보 추출 = {}" , attrs);
+
+        // TODO DB 조회해서, 실제 존재하는 사람인가? -> 있으면 기존에 있던 사람 -> 통과! + 멤버 반환, 없으면 -> 구글로그인 성공한 처음 요청 -> 회원가입 진행
+//        Member member = memberService.findOrCreateMember(attrs.get()); attr에서 구글 아이디로 조회해야 할 듯...?
+        Member member =  memberRepository.findByGoogleId(attrs.get("sub").toString()).get(); // 나중에 삭제해야함
+
+        log.info("회원 구글 아이디로 db 조회 = {}" , member.getNickname());
+
+        //멤버 아이디를 키값으로 해서 redis 에 구글 엑세스 토큰 저장
+        redisUtil.saveGoogleAccessToken(member.getId(), googleAccessToken);
+        log.info("멤버 아이디를 키값으로 해서 redis 에 구글 엑세스 토큰 저장 ");
+
+
+        // jwt 생성 -> 우리 서버 자체 access 토큰
+        String accessToken = jwtUtil.createAccessToken(member);
+        log.info(" 우리 서버 자체 access 토큰 생성 = {} ",accessToken);
+
+
+        // 응답 생성
         String jsonResponse = om.writeValueAsString(ApiResponse.onSuccess("로그인 성공"));
+        jwtUtil.setAccessTokenHeader(response, accessToken); //헤더에 엑세스 토큰 넣기
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.getWriter().write(jsonResponse);
+
     }
 
-    // 로그인 성공 시 리프레시 토큰을 반환하는 메서드
-    private String getRefreshToken(Authentication authentication) {
-        OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
-
-        OAuth2AuthorizedClient authorizedClient = authorizedClientService.loadAuthorizedClient(
-                oauthToken.getAuthorizedClientRegistrationId(),
-                oauthToken.getName()
-        );
-
-        return authorizedClient.getRefreshToken().getTokenValue();
-    }
 }

--- a/src/main/java/channeling/be/domain/member/application/MemberService.java
+++ b/src/main/java/channeling/be/domain/member/application/MemberService.java
@@ -1,4 +1,8 @@
 package channeling.be.domain.member.application;
 
+import channeling.be.domain.member.domain.Member;
+
 public interface MemberService {
+    Member findOrCreateMember();
+
 }

--- a/src/main/java/channeling/be/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/channeling/be/domain/member/application/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package channeling.be.domain.member.application;
 
+import channeling.be.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service
 public class MemberServiceImpl implements MemberService {
+    @Override
+    public Member findOrCreateMember() {
+        return null;
+    }
 }

--- a/src/main/java/channeling/be/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/channeling/be/domain/member/domain/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package channeling.be.domain.member.domain.repository;
 import channeling.be.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByGoogleId(String googleId);
 }

--- a/src/main/java/channeling/be/domain/member/presentation/MemberController.java
+++ b/src/main/java/channeling/be/domain/member/presentation/MemberController.java
@@ -1,11 +1,48 @@
 package channeling.be.domain.member.presentation;
 
+import channeling.be.domain.auth.annotation.LoginMember;
+import channeling.be.domain.member.domain.Member;
+import channeling.be.global.infrastructure.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@Slf4j
 @RequestMapping("/members")
 public class MemberController {
+    private final RedisUtil redisUtil;
+
+    /**
+     * 테스트용 컨트롤러 -> 나중에 삭제해 주세요!
+     */
+
+    @GetMapping("/getMemberInfo")
+    public String getMemberInfo(@LoginMember Member member) {
+        return String.format(
+                "ID: %d, 닉네임: %s, 구글 이메일: %s, 프로필 이미지: %s, 인스타: %s, 틱톡: %s, 페이스북: %s, 트위터: %s, 구글ID: %s",
+                member.getId(),
+                member.getNickname(),
+                member.getGoogleEmail(),
+                member.getProfileImage(),
+                member.getInstagramLink(),
+                member.getTiktokLink(),
+                member.getFacebookLink(),
+                member.getTwitterLink(),
+                member.getGoogleId()
+        );
+    }
+
+    /**
+     * 테스트용 컨트롤러 -> 나중에 삭제해 주세요!
+     */
+    @GetMapping("/getGoogleAceessFromRedis")
+    public String getGoogleAceessFromRedis(@LoginMember Member member) {
+        String googleAccessToken = redisUtil.getGoogleAccessToken(member.getId());
+        log.info("googleAccessToken = {}", googleAccessToken);
+        return googleAccessToken;
+    }
 }

--- a/src/main/java/channeling/be/global/config/RedisConfig.java
+++ b/src/main/java/channeling/be/global/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package channeling.be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    // Redis 서버 호스트 (ex: localhost, redis.mycompany.com)
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    // Redis 서버 포트
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    /**
+     * Lettuce 기반 RedisConnectionFactory Bean.
+     * 애플리케이션에서 Redis에 접근할 때  * Redis 커넥션 설정 & 템플릿 bean
+     * + 커넥션을 생성·관리합니다.
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // Standalone(단일 노드) 환경 설정
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        return new LettuceConnectionFactory(config);
+    }
+
+    /**
+     * Redis 문자열 키/값 처리를 위한 StringRedisTemplate Bean 등록.
+     * RedisUtil에서 이 템플릿을 주입받아 사용합니다.
+     */
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/channeling/be/global/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/channeling/be/global/infrastructure/jwt/JwtUtil.java
@@ -1,0 +1,57 @@
+package channeling.be.global.infrastructure.jwt;
+
+import channeling.be.domain.member.domain.Member;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+/**
+ * JWT 관련 유틸리티 기능을 정의하는 인터페이스.
+ */
+public interface JwtUtil {
+    /**
+     * 회원 정보를 기반으로 액세스 토큰을 생성합니다.
+     * @param member 토큰 생성 대상 회원 정보
+     * @return 생성된 액세스 토큰 문자열
+     */
+    String createAccessToken(Member member);
+
+
+    /**
+     * HTTP 요청 헤더에서 액세스 토큰을 추출합니다.
+     * @param request HTTP 요청 객체
+     * @return 액세스 토큰이 존재하면 Optional에 담아 반환, 없으면 빈 Optional
+     */
+    Optional<String> extractAccessToken(HttpServletRequest request);
+
+    /**
+     * 액세스 토큰에서 회원 ID(주로 userId)를 추출합니다.
+     * @param accessToken 액세스 토큰 문자열
+     * @return 회원 ID가 존재하면 Optional에 담아 반환, 없으면 빈 Optional
+     */
+    Optional<String> extractGoogleId(String accessToken);
+
+    /**
+     * HTTP 응답 헤더에 액세스 토큰을 설정합니다.
+     * @param response HTTP 응답 객체
+     * @param accessToken 액세스 토큰 문자열
+     */
+    void setAccessTokenHeader(HttpServletResponse response, String accessToken);
+
+    /**
+     * 토큰의 유효성을 검사합니다.
+     * (서명 검증, 만료 여부 등)
+     * @param token 검사 대상 토큰 문자열
+     * @return 유효하면 true, 아니면 false
+     */
+    boolean isTokenValid(String token);
+
+    /**
+     * 해당 액세스 토큰이 블랙리스트에 포함되어 있는지 검사합니다.
+     * (예: 로그아웃 등으로 무효화된 토큰 확인)
+     * @param accessToken 검사 대상 액세스 토큰 문자열
+     * @return 블랙리스트에 있으면 true, 아니면 false
+     */
+    boolean isTokenInBlackList(String accessToken);
+}

--- a/src/main/java/channeling/be/global/infrastructure/jwt/JwtUtilImpl.java
+++ b/src/main/java/channeling/be/global/infrastructure/jwt/JwtUtilImpl.java
@@ -1,0 +1,117 @@
+package channeling.be.global.infrastructure.jwt;
+
+import channeling.be.domain.member.domain.Member;
+import channeling.be.global.infrastructure.redis.RedisUtil;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.Optional;
+
+
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+@Setter(value = AccessLevel.PRIVATE)
+@Slf4j
+public class JwtUtilImpl implements JwtUtil {
+
+    private final RedisUtil redisUtil;
+
+    /** JWT 서명에 사용할 비밀키 */
+    @Value("${jwt.secret}")
+    private String secret;
+
+    /** 액세스 토큰 만료 시간 */
+    @Value("${jwt.access.expiration}")
+    private Long accessExpiration;
+
+    /** HTTP 요청/응답 헤더에 사용할 액세스 토큰 키 이름 */
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    public static String BLACKLIST_ACCESS_TOKEN_PREFIX = "BL_AT_";
+
+
+    /** JWT subject 값 - 액세스 토큰 구분용 */
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    /** JWT 클레임 키 - 구글 아이디 */
+    private static final String GOOGLE_CLAIM = "googleId";
+
+    /** JWT 클레임 키 - 회원 ID */
+    private static final String USERID_CLAIM = "id";
+
+    /** HTTP Authorization 헤더의 토큰 앞에 붙는 접두사 */
+    private static final String BEARER = "Bearer ";
+
+    @Override
+    public String createAccessToken(Member member) {
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(System.currentTimeMillis() + accessExpiration * 1000))
+                .withClaim(USERID_CLAIM, member.getId())
+                .withClaim(GOOGLE_CLAIM, member.getGoogleId())
+                .sign(Algorithm.HMAC512(secret));
+    }
+
+
+    @Override
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader)).filter(
+                accessToken -> accessToken.startsWith(BEARER)
+        ).map(accessToken -> accessToken.replace(BEARER, ""));
+    }
+
+
+    @Override
+    public Optional<String> extractGoogleId(String accessToken) {
+        try {
+
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secret))
+                    .build()
+                    .verify(accessToken)
+                    .getClaim(GOOGLE_CLAIM)
+                    .asString());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, accessToken);
+    }
+
+
+    @Override
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secret)).build().verify(token);
+            return true;
+        } catch (TokenExpiredException ex) {
+            log.error("만료된 JWT 토큰입니다.");
+            return false;
+        } catch (Exception e) {
+            log.error("유효하지 않은 Token입니다 {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isTokenInBlackList(String accessToken) {
+        // Redis에서 블랙리스트로 저장된 토큰 확인
+        String blacklistToken = redisUtil.getData( BLACKLIST_ACCESS_TOKEN_PREFIX + accessToken);
+        return blacklistToken != null;    }
+}

--- a/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
+++ b/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
@@ -1,0 +1,95 @@
+package channeling.be.global.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * 🔹 Redis 편의 메서드를 모아 둔 유틸리티 클래스
+ *    - 문자열(String) 타입 전용 StringRedisTemplate을 주입받아 사용
+ *    - 기본 CRUD + 만료시간 설정 기능 제공
+ */
+@RequiredArgsConstructor
+@Component
+public class RedisUtil {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /** redis에 저장하는 구글 엑세스의 지속 시간 **/
+    @Value("${jwt.google.access.expiration}")
+    private Long googleAccessExpiration;
+
+    /** Redis에 저장할 구글 액세스 토큰 키 접두사 */
+    private final static String GOOGLE_ACCESS_TOKEN_PREFIX = "GOOGLE_AT_";
+
+
+    /**
+     *  key로부터 value 조회
+     *  @return 값이 없으면 null
+     *  */
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    /**
+     *  해당 key 존재 여부 확인
+     *  @return 존재하면 true, 없으면 false
+     *  */
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
+    }
+
+
+    /**
+     *  만료시간 없이 key‑value 저장
+     *  */
+    public void setData(String key, String value) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+
+    /**
+     *  만료시간(duration 초)과 함께 key‑value 저장
+     *  @param duration 초 단위 TTL(Time To Live)
+     *  */
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    /**
+     *  key 삭제
+     *  */
+    public void deleteData(String key) {
+        stringRedisTemplate.delete(key);
+    }
+
+
+    /**
+     * 멤버 ID를 키로 하여 구글 액세스 토큰을 Redis에 만료시간과 함께 저장합니다.
+     *
+     * @param memberId 멤버의 고유 ID
+     * @param googleAccessToken 구글 액세스 토큰
+     */
+    public void saveGoogleAccessToken(Long memberId, String googleAccessToken) {
+        String key = GOOGLE_ACCESS_TOKEN_PREFIX + memberId;
+        stringRedisTemplate.opsForValue().set(key, googleAccessToken, Duration.ofSeconds(googleAccessExpiration)); // 덮어씌우기
+    }
+
+    /**
+     * 멤버 ID로 저장된 구글 액세스 토큰을 조회합니다.
+     *
+     * @param memberId 멤버의 고유 ID
+     * @return 저장된 구글 액세스 토큰 (없으면 null)
+     */
+    public String getGoogleAccessToken(Long memberId) {
+        String key = GOOGLE_ACCESS_TOKEN_PREFIX + memberId;
+        return stringRedisTemplate.opsForValue().get(key);
+    }
+}

--- a/src/main/java/channeling/be/global/resolver/WebMvcConfig.java
+++ b/src/main/java/channeling/be/global/resolver/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package channeling.be.global.resolver;
+
+import channeling.be.domain.auth.annotation.LoginMemberArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebMvcConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,9 @@
+jwt:
+  secret: ${JWT_SECRET}
+  access:
+    expiration: 3600      # 초 단위, 60min
+    header: Authorization
+
+  google:
+    access:
+      expiration: 3600      # 초 단위, 60min


### PR DESCRIPTION
## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)

[[FEAT] 테스트용 api 구현 완료](https://github.com/umc-8th-

[[FEAT] @LoginMember 커스텀 어노테이션 구현 완료](https://github.com/umc-8th-

[[FEAT] 로그인 이외의 요청 시, jwt 토큰 검증 및 인가 기능]

[[FEAT] 구글 로그인 성공 시, 자체 토큰 발급 및 redis에 구글 엑세스 토큰 저장 기능 구현 완료]
[[FEAT] JWT, REDIS 기능 구현]


## ⚙️ 주요 작업 (선택 사항)
- [x] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [x] 외부 라이브러리 추가/제거 (라이브러리 명시)
jwt, redis 라이브러리 추가

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)

#26 
## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.

pull 받고, 테스트용 컨트롤러로 한 번씩 테스트 해주세요!

redis 서버 띄운 상태해서 진행해야 합니다.

인스턴스 ec2 내부에 redis 설치하고, 내부에서만 통신할거라서, 따로 비밀번호 설정하지 않았고, 외부 접속도 기본 설정으로 받지 않도록 하였습니다! 

redis 설정 파일은 초 단위로 적어놓았고, 코드단에서 *1000으로 맞춰 놓았습니다!

구글 로그인 url은 member/login/google 입니다!