### PR TITLE
[CHORE] Task 테이블 Enum 타입 칼럼에 String값 허용

### DIFF
--- a/src/main/java/channeling/be/domain/task/domain/Task.java
+++ b/src/main/java/channeling/be/domain/task/domain/Task.java
@@ -20,11 +20,14 @@ public class Task extends BaseEntity {
     private Report report;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private TaskStatus overviewStatus;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private TaskStatus analysisStatus;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private TaskStatus ideaStatus;
 }


### PR DESCRIPTION
## PR 제목
[CHORE] Task 테이블 Enum 타입 칼럼에 String값 허용

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [x] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [x] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
- task 테이블 만들 때 개요, 분석, 아이디어 status에 @Enumerated(EnumType.STRING) 붙이는 걸 까먹어서 추가했습니다. 

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [x] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#49 

## 💬 기타 (선택 사항)
**develop 머지 성공 후 main에 바로 머지 예정!(배포 환경에서 kafka에 메시지 전달 되는지 확인해야 됨)**