### PR TITLE
[FIX] 컨테이너 종료 후 이미지 삭제하는 걸로 수정

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -34,19 +34,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-      # 이전 Docker 이미지 제거
-      - name: Clean up old Docker images
-        run: |
-          # hadoroke/channeling-be의 이전 Docker 이미지 제거(latest 제외)
-          docker images hadoroke/channeling-be --format "{{.ID}}" | \
-          head -n -1 | xargs -r docker rmi -f
-                      
-          # dangling 이미지 제거
-          docker image prune -f
 
-      # Docker 이미지 Pull
-      - name: Pull Docker image
-        run: docker pull ${{ secrets.DOCKER_USERNAME }}/channeling-be:latest
 
 
       # spring-app이 실행중인 경우 중지 & 삭제
@@ -55,6 +43,19 @@ jobs:
           cd deploy-configs
           docker-compose stop spring-app || true 
           docker-compose rm -f spring-app || true 
+
+      # 이전 Docker 이미지 제거
+      - name: Clean up old Docker images
+        run: |
+          # hadoroke/channeling-be의 모든 Docker 이미지 제거
+          docker images hadoroke/channeling-be -q | xargs -r docker rmi -f
+          
+          # dangling 이미지 제거
+          docker image prune -f 
+
+      # Docker 이미지 Pull
+      - name: Pull Docker image
+        run: docker pull ${{ secrets.DOCKER_USERNAME }}/channeling-be:latest
 
       # spring-app 다시 실행
       - name: Deploy spring-app


### PR DESCRIPTION
## PR 제목
[FIX] 컨테이너 종료 후 이미지 삭제하는 걸로 수정

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
- 도커 컨테이너를 종료하고 이미지를 삭제해야 되는데, 이미지를 쓰고 있는 컨테이너가 있는 상황에서 이미지를 삭제하려고 해서 오류 발생
- 컨테이너 종료 -> 기존 이미지 삭제 -> 최신 이미지 받아옴 -> 배포 순으로 변경

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#80 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.