### PR TITLE
[FEAT]: 리포트 분석 상태 조회

### DIFF
--- a/src/main/java/channeling/be/domain/report/application/ReportService.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportService.java
@@ -1,4 +1,8 @@
 package channeling.be.domain.report.application;
 
+import channeling.be.domain.member.domain.Member;
+import channeling.be.domain.report.presentation.ReportResDto;
+
 public interface ReportService {
+    ReportResDto.getReportAnalysisStatus getReportAnalysisStatus(Member member, Long taskId);
 }

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -1,5 +1,13 @@
 package channeling.be.domain.report.application;
 
+import channeling.be.domain.member.domain.Member;
+import channeling.be.domain.report.domain.Report;
+import channeling.be.domain.report.presentation.ReportConverter;
+import channeling.be.domain.report.presentation.ReportResDto;
+import channeling.be.domain.task.domain.Task;
+import channeling.be.domain.task.domain.repository.TaskRepository;
+import channeling.be.response.code.status.ErrorStatus;
+import channeling.be.response.exception.handler.TaskHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +16,22 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service
 public class ReportServiceImpl implements ReportService {
+    private final TaskRepository taskRepository;
+
+    @Override
+    public ReportResDto.getReportAnalysisStatus getReportAnalysisStatus(Member member, Long taskId) {
+        //task 조회 -> 없으면 애러 반환 -> 연관된 리포트 연관 조인
+        Task task =taskRepository.findByIdFetchWithReportAndMember(taskId)
+                .orElseThrow(()-> new TaskHandler(ErrorStatus._TASK_NOT_FOUND));
+        // 만약 연관된 리포트가 없다면..? 오류 처리
+        Report report = task.getReport();
+        if (report == null) {
+            throw new TaskHandler(ErrorStatus._TASK_NOT_REPORT);
+        }
+        // 만약 해당 리포트의 주인이 멤버가 아닌 경우 오류 처리
+        if (!report.getVideo().getChannel().getMember().getId().equals(member.getId())) {
+            throw new TaskHandler(ErrorStatus._REPORT_NOT_MEMBER);
+        }
+        return ReportConverter.toReportAnalysisStatus(task,report);
+    }
 }

--- a/src/main/java/channeling/be/domain/report/presentation/ReportController.java
+++ b/src/main/java/channeling/be/domain/report/presentation/ReportController.java
@@ -1,11 +1,27 @@
 package channeling.be.domain.report.presentation;
 
+import channeling.be.domain.auth.annotation.LoginMember;
+import channeling.be.domain.member.domain.Member;
+import channeling.be.domain.report.application.ReportService;
+import channeling.be.response.exception.handler.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/reports")
-public class ReportController {
+public class ReportController implements ReportSwagger{
+    private final ReportService reportService;
+
+
+    @GetMapping("/status/{task-id}")
+    public ApiResponse<ReportResDto.getReportAnalysisStatus> getReportAnalysisStatus(
+            @PathVariable("task-id") Long taskId,
+            @LoginMember Member member) {
+        return ApiResponse.onSuccess(reportService.getReportAnalysisStatus(member, taskId));
+    }
+
 }

--- a/src/main/java/channeling/be/domain/report/presentation/ReportConverter.java
+++ b/src/main/java/channeling/be/domain/report/presentation/ReportConverter.java
@@ -1,0 +1,15 @@
+package channeling.be.domain.report.presentation;
+
+import channeling.be.domain.report.domain.Report;
+import channeling.be.domain.task.domain.Task;
+
+public class ReportConverter {
+    public static ReportResDto.getReportAnalysisStatus toReportAnalysisStatus(Task task, Report report) {
+        return new ReportResDto.getReportAnalysisStatus(
+                task.getId(),
+                report.getId(),
+                task.getOverviewStatus(),
+                task.getAnalysisStatus(),
+                task.getIdeaStatus());
+    }
+}

--- a/src/main/java/channeling/be/domain/report/presentation/ReportResDto.java
+++ b/src/main/java/channeling/be/domain/report/presentation/ReportResDto.java
@@ -1,0 +1,15 @@
+package channeling.be.domain.report.presentation;
+
+import channeling.be.domain.task.domain.TaskStatus;
+
+public class ReportResDto {
+
+    public record getReportAnalysisStatus(
+            Long taskId,
+            Long reportId,
+            TaskStatus overviewStatus,
+            TaskStatus analysisStatus,
+            TaskStatus ideaStatus
+    ) {
+    }
+}

--- a/src/main/java/channeling/be/domain/report/presentation/ReportSwagger.java
+++ b/src/main/java/channeling/be/domain/report/presentation/ReportSwagger.java
@@ -1,0 +1,22 @@
+package channeling.be.domain.report.presentation;
+
+import channeling.be.domain.auth.annotation.LoginMember;
+import channeling.be.domain.member.domain.Member;
+import channeling.be.response.exception.handler.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "리포트 API", description = "리포트 관련 API입니다.")
+public interface ReportSwagger{
+
+    @Operation(summary = "리포트 분석 상태를 조회합니다.", description = "순서대로 개요, 분석, 아이디어.")
+    @GetMapping("/status/{task-id}")
+    ApiResponse<ReportResDto.getReportAnalysisStatus> getReportAnalysisStatus(
+            @Parameter(description = "상태를 조회할 태스크 아이디 (리포트 분석 요청 시, 응답에 포함 되어 있습니다.)", example = "1")
+            @PathVariable("task-id") Long taskId,
+            @Parameter(hidden = true)
+            @LoginMember Member member);
+}

--- a/src/main/java/channeling/be/domain/task/domain/repository/TaskRepository.java
+++ b/src/main/java/channeling/be/domain/task/domain/repository/TaskRepository.java
@@ -2,6 +2,20 @@ package channeling.be.domain.task.domain.repository;
 
 import channeling.be.domain.task.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
+    @Query("""
+    SELECT t
+    FROM Task t
+    JOIN FETCH t.report r
+    JOIN FETCH r.video v
+    JOIN FETCH v.channel c
+    JOIN FETCH c.member m
+    WHERE t.id = :taskId
+""")
+    Optional<Task> findByIdFetchWithReportAndMember(@Param("taskId") Long taskId);
 }

--- a/src/main/java/channeling/be/response/code/status/ErrorStatus.java
+++ b/src/main/java/channeling/be/response/code/status/ErrorStatus.java
@@ -43,6 +43,13 @@ public enum ErrorStatus implements BaseErrorCode {
     _IDEA_NOT_FOUND(HttpStatus.BAD_REQUEST, "IDEA400", "존재하지 않는 아이디어입니다."),
     _IDEA_NOT_MEMBER(HttpStatus.BAD_REQUEST, "IDEA403", "해당 아이디어를 소유한 멤버가 아닙니다."),
 
+    //태스크 관련 에러
+    _TASK_NOT_FOUND(HttpStatus.BAD_REQUEST, "TASK400", "존재하지 않는 태스크입니다."),
+    _TASK_NOT_REPORT(HttpStatus.BAD_REQUEST, "TASK400", "해당 태스크와 연관된 리포트가 없습니다."),
+
+    //리포트 관련 에러
+    _REPORT_NOT_MEMBER(HttpStatus.BAD_REQUEST, "IDEA403", "해당 리포트를 소유한 멤버가 아닙니다."),
+
     ;
 
 

--- a/src/main/java/channeling/be/response/exception/handler/TaskHandler.java
+++ b/src/main/java/channeling/be/response/exception/handler/TaskHandler.java
@@ -1,0 +1,10 @@
+package channeling.be.response.exception.handler;
+
+import channeling.be.response.code.BaseErrorCode;
+import channeling.be.response.exception.GeneralException;
+
+public class TaskHandler extends GeneralException {
+    public TaskHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)

[FEAT]: 리포트 분석 상태 조회

## ✨ 변경 유형 (하나 이상 선택)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [x] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)


<img width="866" height="763" alt="image" src="https://github.com/user-attachments/assets/69e3cefb-4c70-4857-a17c-e6d988d07213" />

존재하지 않는 테스크일 경우
<img width="811" height="817" alt="image" src="https://github.com/user-attachments/assets/f4b390ae-ea70-497f-ba21-e281f837ccb9" />




## ⚙️ 주요 작업 (선택 사항)
- [x] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.

위 캡쳐본에 는 존재하지 않지만,
태스크는 존재하지만, 태스크와 연관된 리포트가 없는 경우,
태스크와, 리포트가 모두 존재하지만, 요청자가 리포트의 주인이 아닌 경우
에 대한 케이스에 대한 오류 처리를 진행하였습니다.

테스크 -> 리포트 -> 비디오 -> 채널 -> 멤버 순으로 조인을 진행해야 해서,
커스텀 메소드를 통해, 한방 쿼리로 조인해서 가져오도록 하여, n+1 문제 해결하였습니다.



