### PR TITLE
[FEAT] 로그인 시, 응답에 최초 로그인 여부 추가

### DIFF
--- a/src/main/java/channeling/be/domain/auth/application/MemberOauth2UserService.java
+++ b/src/main/java/channeling/be/domain/auth/application/MemberOauth2UserService.java
@@ -50,20 +50,22 @@ public class MemberOauth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     @Transactional
     public LoginResult executeGoogleLogin(Map<String, Object> attrs, String googleAccessToken) {
-        Member member = memberService.findOrCreateMember(
+        MemberResult memberResult = memberService.findOrCreateMember(
             attrs.get("sub").toString(),
             attrs.get("email").toString(),
             attrs.get("name").toString(),
             attrs.get("picture").toString()
 
         );
-
+        Member member = memberResult.member;
         redisUtil.saveGoogleAccessToken(member.getId(), googleAccessToken);
 
         Channel channel = channelService.updateOrCreateChannelByMember(member);
 
-        return new LoginResult(member, channel);
+        return new LoginResult(member, channel, memberResult.isNew);
     }
 
-    public record LoginResult(Member member, Channel channel) {}
+    public record LoginResult(Member member, Channel channel, boolean isNew) {}
+    public record MemberResult(Member member, boolean isNew) {}
+
 }

--- a/src/main/java/channeling/be/domain/auth/handler/Oauth2LoginSuccessHandler.java
+++ b/src/main/java/channeling/be/domain/auth/handler/Oauth2LoginSuccessHandler.java
@@ -81,6 +81,7 @@ public class Oauth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 .queryParam("token", accessToken)
                 .queryParam("message", "Success")
                 .queryParam("channelId", result.channel().getId())
+                .queryParam("isNew", result.isNew())
                 .build()
                 .toUriString();
 

--- a/src/main/java/channeling/be/domain/member/application/MemberService.java
+++ b/src/main/java/channeling/be/domain/member/application/MemberService.java
@@ -1,12 +1,13 @@
 package channeling.be.domain.member.application;
 
+import channeling.be.domain.auth.application.MemberOauth2UserService;
 import channeling.be.domain.member.domain.Member;
 import channeling.be.domain.member.presentation.MemberResDTO;
 import static channeling.be.domain.member.presentation.MemberReqDTO.*;
 
 public interface MemberService {
 
-    Member findOrCreateMember(String googleId,String email, String nickname, String profileImage);
+    MemberOauth2UserService.MemberResult findOrCreateMember(String googleId, String email, String nickname, String profileImage);
     MemberResDTO.updateSnsRes updateSns(Member loginMember, updateSnsReq updateSnsReq);
     MemberResDTO.updateProfileImageRes updateProfileImage(Member loginMember, ProfileImageUpdateReq updateProfileImageReq);
     MemberResDTO.getMemberInfo getMemberInfo(Member loginMember);

--- a/src/main/java/channeling/be/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/channeling/be/domain/member/application/MemberServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static channeling.be.domain.auth.application.MemberOauth2UserService.*;
 import static channeling.be.domain.member.presentation.MemberReqDTO.*;
 
 @RequiredArgsConstructor
@@ -55,16 +56,20 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	@Transactional
-    public Member findOrCreateMember(String googleId, String email, String nickname, String profileImage) {
+    public MemberResult findOrCreateMember(String googleId, String email, String nickname, String profileImage) {
 		return memberRepository.findByGoogleId(googleId)
-			.orElseGet(() -> memberRepository.save(
-				Member.builder()
-					.googleId(googleId)
-					.googleEmail(email)
-					.nickname(nickname)
-					.profileImage(profileImage)
-					.build()
-			));
+				.map(member -> new MemberResult(member, false)) // 기존 회원
+				.orElseGet(() -> {
+					Member newMember = memberRepository.save(
+							Member.builder()
+									.googleId(googleId)
+									.googleEmail(email)
+									.nickname(nickname)
+									.profileImage(profileImage)
+									.build()
+					);
+					return  new MemberResult(newMember, true); // 신규 회원
+				});
 	}
 
 


### PR DESCRIPTION
## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)
[FEAT] 로그인 시, 응답에 최초 로그인 여부 추가

## ✨ 변경 유형 (하나 이상 선택)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)

기존에 record를 사용하셔서 로그인 과정을 구현하고 계신 것 같아서,
LoginResult에 isNew를 추가하기 위해서  memberService.findOrCreateMember 의 응답을 member에서 memberResult라는 record로 변환하였습니다

로컬 상에서 yml 을 create로 두고 db 리셋
<img width="1537" height="126" alt="image" src="https://github.com/user-attachments/assets/a8c88c27-a105-4978-8ebc-7ccac7b57129" />

로그인 결과 

http://localhost:5173/auth/callback?token=eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImV4cCI6MTc1NDQxNTQ1NywiaWQiOjEsImdvb2dsZUlkIjoiMTEzMDY0NjczMjE5MzcyNjAzOTM0In0.DHQx9NMiZ8nbbKHYsRt4_yrfZI0k-a9-cPq_JKfMIMMJ_UzG5_kfZvJcciCnIaX0iOXRNEqgsRCw3GpXJjtA_A&message=Success&channelId=1&isNew=true

db에 멤버 생성 확인

<img width="1541" height="274" alt="image" src="https://github.com/user-attachments/assets/207fa48d-2700-4758-a4f3-d777b022d9e4" />

재로그인 결과
http://localhost:5173/auth/callback?token=eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImV4cCI6MTc1NDQxNTUxNiwiaWQiOjEsImdvb2dsZUlkIjoiMTEzMDY0NjczMjE5MzcyNjAzOTM0In0.AXs0kEoarIytl3efIyN-jWGFg7i6rHT-y38hNOIIjsVxSfbEcbmxSqnVsdE0oCDbWl44PzN2gEtaP30IphlNhQ&message=Success&channelId=1&isNew=false

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.