### PR TITLE
[FEAT]: 리포트 분석 요청

### DIFF
--- a/src/main/java/channeling/be/domain/report/application/ReportService.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportService.java
@@ -11,4 +11,6 @@ public interface ReportService {
 	Report getReportByIdAndMember(Long reportId, Member member);
 
 	ReportResDto.getCommentsByType getCommentsByType(Report report, CommentType commentType);
+
+    ReportResDto.createReport createReport(Member member, Long videoId);
 }

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -9,20 +9,42 @@ import channeling.be.domain.report.presentation.ReportConverter;
 import channeling.be.domain.report.presentation.ReportResDto;
 import channeling.be.domain.task.domain.Task;
 import channeling.be.domain.task.domain.repository.TaskRepository;
+import channeling.be.domain.video.domain.Video;
+import channeling.be.domain.video.domain.repository.VideoRepository;
+import channeling.be.global.infrastructure.jwt.JwtUtil;
+import channeling.be.global.infrastructure.redis.RedisUtil;
 import channeling.be.response.code.status.ErrorStatus;
 import channeling.be.response.exception.handler.ReportHandler;
 import channeling.be.response.exception.handler.TaskHandler;
+import channeling.be.response.exception.handler.VideoHandler;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
+@Slf4j
 public class ReportServiceImpl implements ReportService {
     private final TaskRepository taskRepository;
 	private final ReportRepository reportRepository;
 	private final CommentRepository commentRepository;
+    private final VideoRepository videoRepository;
+    private final RedisUtil redisUtil;
+    private final JwtUtil jwtUtil;
+
     @Override
     public ReportResDto.getReportAnalysisStatus getReportAnalysisStatus(Member member, Long taskId) {
         //task 조회 -> 없으면 애러 반환 -> 연관된 리포트 연관 조인
@@ -51,4 +73,70 @@ public class ReportServiceImpl implements ReportService {
 	public ReportResDto.getCommentsByType getCommentsByType(Report report, CommentType commentType) {
 		return ReportConverter.toCommentsByType(commentType, commentRepository.findTop5ByReportAndCommentType(report, commentType));
 	}
+
+    @Override
+    @Transactional
+    public ReportResDto.createReport createReport(Member member, Long videoId) {
+        // 요청 영상의 주인인지 확인
+        if (!videoRepository.existsById(videoId)) {
+            throw new VideoHandler(ErrorStatus._VIDEO_NOT_FOUND) ;
+        }
+
+        Video video = videoRepository.findByIdWithMemberId(videoId, member.getId())
+                .orElseThrow(() -> new VideoHandler(ErrorStatus._VIDEO_NOT_MEMBER));
+
+
+        // redis에서 구글 토큰 가져오기 -> 2분 보다 적으면 에러 반환
+        Long ttl = redisUtil.getGoogleAccessTokenExpire(member.getId());
+        log.info("리포트 분석 전, 구글 토큰 TTL (초): {}" , ttl);
+        if (ttl <= 120) {
+            throw new ReportHandler(ErrorStatus._TOKEN_EXPIRED);
+        }
+        String googleAccessToken = redisUtil.getGoogleAccessToken(member.getId());
+        log.info("구글 토큰 : {}" , googleAccessToken);
+        // fastapi 쪽에 요청 보내기
+        // 요청 바디에 보낼 객체 구성
+        Long taskId= sendPostToFastAPI(videoId, googleAccessToken);
+        return new ReportResDto.createReport(taskId);
+    }
+
+    private static Long sendPostToFastAPI(Long videoId, String googleAccessToken) {
+
+        // HTTP 요청 보내기
+        RestTemplate restTemplate = new RestTemplate();
+        // url 설정
+        String url = UriComponentsBuilder
+                .fromHttpUrl("http://localhost:8000/reports")
+                .queryParam("video_id", videoId)
+                .toUriString();
+
+        // requestbody 생성
+        Map<String, String> requestBody = new HashMap<>();
+//        requestBody.put("googleAccessToken", googleAccessToken);
+
+        // 헤더 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // 요청 생성
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(requestBody, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+
+        // 응답 파싱 및 반환
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode root = objectMapper.readTree(response.getBody());
+
+
+            JsonNode resultNode = root.get("result");
+            if (resultNode != null && resultNode.has("task_id")) {
+                return resultNode.get("task_id").asLong();
+            } else {
+                throw new IllegalStateException("응답에 result.task_id가 없습니다.");
+            }
+
+
+        } catch (Exception e) {
+            throw new RuntimeException("FastAPI 응답 파싱 실패", e);
+        }    }
 }

--- a/src/main/java/channeling/be/domain/report/presentation/ReportController.java
+++ b/src/main/java/channeling/be/domain/report/presentation/ReportController.java
@@ -33,4 +33,13 @@ public class ReportController implements ReportSwagger{
         return ApiResponse.onSuccess(reportService.getCommentsByType(report, commentType));
 
     }
+    @Override
+    @PostMapping("/{video-id}")
+    public ApiResponse<ReportResDto.createReport> createReport(
+            @PathVariable("video-id") Long videoId,
+            @LoginMember Member member) {
+        return ApiResponse.onSuccess(reportService.createReport(member, videoId));
+    }
+
+
 }

--- a/src/main/java/channeling/be/domain/report/presentation/ReportResDto.java
+++ b/src/main/java/channeling/be/domain/report/presentation/ReportResDto.java
@@ -27,4 +27,9 @@ public class ReportResDto {
             String content
     ) {
     }
+
+    public record createReport(
+            Long taskId
+    ) {
+    }
 }

--- a/src/main/java/channeling/be/domain/report/presentation/ReportSwagger.java
+++ b/src/main/java/channeling/be/domain/report/presentation/ReportSwagger.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "리포트 API", description = "리포트 관련 API입니다.")
 public interface ReportSwagger{
@@ -29,6 +30,16 @@ public interface ReportSwagger{
             @PathVariable("report-id") Long reportId,
             @Parameter(description = "댓글의 타입.")
             @RequestParam("type") CommentType commentType,
+            @Parameter(hidden = true)
+            @LoginMember Member member);
+
+
+
+    @Operation(summary = "리포트 분석을 요청합니다.", description = "영상 아이디를 입력 받습니다.")
+    @PostMapping("/{video-id}")
+    ApiResponse<ReportResDto.createReport> createReport(
+            @Parameter(description = "리포트 분석을 요청할 영상 아이디 (본인 채널의 영상이어야 합니다.)", example = "1")
+            @PathVariable("video-id") Long videoId,
             @Parameter(hidden = true)
             @LoginMember Member member);
 }

--- a/src/main/java/channeling/be/domain/video/domain/repository/VideoRepository.java
+++ b/src/main/java/channeling/be/domain/video/domain/repository/VideoRepository.java
@@ -9,6 +9,8 @@ import channeling.be.domain.video.domain.VideoCategory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
 public interface VideoRepository extends JpaRepository<Video, Long> {
@@ -20,4 +22,13 @@ public interface VideoRepository extends JpaRepository<Video, Long> {
 	Slice<Video> findByChannelIdAndVideoCategoryAndUploadDateLessThanOrderByUploadDateDesc(Long channelId, VideoCategory type, LocalDateTime cursor, Pageable pageable);
 
 	Optional<Video> findByYoutubeVideoId(String youtubeVideoId);
+
+	@Query("""
+    SELECT v
+    FROM Video v
+    JOIN v.channel c
+    JOIN c.member m
+    WHERE v.id = :videoId AND m.id = :memberId
+""")
+	Optional<Video> findByIdWithMemberId(@Param("videoId")Long videoId, @Param("memberId")Long memberId);
 }

--- a/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
+++ b/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 🔹 Redis 편의 메서드를 모아 둔 유틸리티 클래스
@@ -91,5 +92,11 @@ public class RedisUtil {
     public String getGoogleAccessToken(Long memberId) {
         String key = GOOGLE_ACCESS_TOKEN_PREFIX + memberId;
         return stringRedisTemplate.opsForValue().get(key);
+    }
+
+    public Long getGoogleAccessTokenExpire(Long memberId) {
+        String key = GOOGLE_ACCESS_TOKEN_PREFIX + memberId;
+        // TTL (Time To Live)을 초 단위로 가져옴
+        return stringRedisTemplate.getExpire(key, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/channeling/be/response/code/status/ErrorStatus.java
+++ b/src/main/java/channeling/be/response/code/status/ErrorStatus.java
@@ -48,8 +48,17 @@ public enum ErrorStatus implements BaseErrorCode {
     _TASK_NOT_REPORT(HttpStatus.BAD_REQUEST, "TASK400", "해당 태스크와 연관된 리포트가 없습니다."),
 
     //리포트 관련 에러
-    _REPORT_NOT_MEMBER(HttpStatus.BAD_REQUEST, "IDEA403", "해당 리포트를 소유한 멤버가 아닙니다."),
-    _REPORT_NOT_FOUND(HttpStatus.BAD_REQUEST, "IDEA400", "존재하지 않는 리포트입니다."),
+    _REPORT_NOT_MEMBER(HttpStatus.BAD_REQUEST, "REPORT403", "해당 리포트를 소유한 멤버가 아닙니다."),
+    _REPORT_NOT_FOUND(HttpStatus.BAD_REQUEST, "REPORT400", "존재하지 않는 리포트입니다."),
+
+    //영상 관련 에러
+    _VIDEO_NOT_FOUND(HttpStatus.BAD_REQUEST, "VIDEO400", "존재하지 않는 영상입니다."),
+    _VIDEO_NOT_MEMBER(HttpStatus.BAD_REQUEST, "VIDEO403", "해당 영상을 소유한 멤버가 아닙니다."),
+
+    //토큰 관련 에러
+    _TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "TOKEN400", "토큰이 만료되었습니다. 재로그인 해주세요.")
+
+
     ;
 
 

--- a/src/main/java/channeling/be/response/exception/handler/VideoHandler.java
+++ b/src/main/java/channeling/be/response/exception/handler/VideoHandler.java
@@ -3,8 +3,8 @@ package channeling.be.response.exception.handler;
 import channeling.be.response.code.BaseErrorCode;
 import channeling.be.response.exception.GeneralException;
 
-public class ReportHandler extends GeneralException {
-    public ReportHandler(BaseErrorCode errorCode) {
-        super(errorCode);
+public class VideoHandler extends GeneralException {
+    public VideoHandler(BaseErrorCode code) {
+        super(code);
     }
 }


### PR DESCRIPTION
## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)

[FEAT]: 리포트 분석 요청

## ✨ 변경 유형 (하나 이상 선택)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [x] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)

1. 존재하는 영상인지 확인
2. 해당 영상이 요청 멤버 소유인지 확인
3. 구글 토큰 redis에서 가져올 때, 만료기간이 2분 보다 낮은 경우 재로그인
4. fastapi 쪽으로 post 요청 

<img width="877" height="725" alt="image" src="https://github.com/user-attachments/assets/50c899cc-0872-4d49-82a9-58bc00aecad5" />



## ⚙️ 주요 작업 (선택 사항)
- [x] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)
#93 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.

1. 현재 fasapi는 인스턴스 내에서 스프링과 같이 돌아가서, localhost8000 이라 생각해서,
local:8000으로 해두었습니다.
2. 원래는 fastapi 에서는 바디로 구글 토큰을 받아야 하지만, 현재 fastapi에서는 받는 요청이 없어서, 바디에 토큰을 받는 부분은 주석 처리해두었습니다.
3. 로컬에서는, fastapi로 와서, 메시지 정상 발급 및 consumer 단 까지 가는 것 까지 확인하였습니다.
4. 리포트 분석 중일 때, 중복 요청을 하는 경우도 예외 처리를 해야 할 지 잘모르겠습니다.
프론트 단에서 간단하게 할 수 있으면, 그 쪽으로 해결해도 될 것 같긴 합니다

