### PR TITLE
[FIX]: enum VideoCategory 유튜브 카테고리값 추가

### DIFF
--- a/src/main/java/channeling/be/domain/video/domain/VideoCategory.java
+++ b/src/main/java/channeling/be/domain/video/domain/VideoCategory.java
@@ -1,5 +1,52 @@
 package channeling.be.domain.video.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
 public enum VideoCategory {
-    LONG, SHORT;
+    FILM_AND_ANIMATION("1", "Film & Animation"),
+    AUTOS_AND_VEHICLES("2", "Autos & Vehicles"),
+    MUSIC("10", "Music"),
+    PETS_AND_ANIMALS("15", "Pets & Animals"),
+    SPORTS("17", "Sports"),
+    SHORT_MOVIES("18", "Short Movies"),
+    TRAVEL_AND_EVENTS("19", "Travel & Events"),
+    GAMING("20", "Gaming"),
+    VIDEOBLOGGING("21", "Videoblogging"),
+    PEOPLE_AND_BLOGS("22", "People & Blogs"),
+    COMEDY("23", "Comedy"),
+    ENTERTAINMENT("24", "Entertainment"),
+    NEWS_AND_POLITICS("25", "News & Politics"),
+    HOWTO_AND_STYLE("26", "Howto & Style"),
+    EDUCATION("27", "Education"),
+    SCIENCE_AND_TECHNOLOGY("28", "Science & Technology"),
+    MOVIES("30", "Movies"),
+    ANIME_ANIMATION("31", "Anime/Animation"),
+    ACTION_ADVENTURE("32", "Action/Adventure"),
+    CLASSICS("33", "Classics"),
+    COMEDY_GENRE("34", "Comedy"),
+    DOCUMENTARY("35", "Documentary"),
+    DRAMA("36", "Drama"),
+    FAMILY("37", "Family"),
+    FOREIGN("38", "Foreign"),
+    HORROR("39", "Horror"),
+    SCI_FI_FANTASY("40", "Sci-Fi/Fantasy"),
+    THRILLER("41", "Thriller"),
+    SHORTS("42", "Shorts"),
+    SHOWS("43", "Shows"),
+    TRAILERS("44", "Trailers");
+
+    private final String id;
+    private final String title;
+
+    public static VideoCategory ofId(String id) {
+        return Arrays.stream(VideoCategory.values())
+            .filter(category -> category.getId().equals(id))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Invalid VideoCategory id: " + id));
+    }
 }

--- a/src/main/java/channeling/be/domain/video/domain/VideoCategory.java
+++ b/src/main/java/channeling/be/domain/video/domain/VideoCategory.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 @Getter
 @AllArgsConstructor
 public enum VideoCategory {
+    NONE("0", "None"),
     FILM_AND_ANIMATION("1", "Film & Animation"),
     AUTOS_AND_VEHICLES("2", "Autos & Vehicles"),
     MUSIC("10", "Music"),

--- a/src/main/java/channeling/be/domain/video/domain/VideoConverter.java
+++ b/src/main/java/channeling/be/domain/video/domain/VideoConverter.java
@@ -21,7 +21,7 @@ public class VideoConverter {
 			.link("https://www.youtube.com/watch?v="+briefDTO.getVideoId())
 			.uploadDate(OffsetDateTime.parse(briefDTO.getPublishedAt(), DateTimeFormatter.ISO_OFFSET_DATE_TIME
 			).toLocalDateTime())
-			.videoCategory("42".equals(detailDTO.getCategoryId()) ? VideoCategory.SHORT : VideoCategory.LONG)
+			.videoCategory(VideoCategory.ofId(detailDTO.getCategoryId()))
 			.build();
 	}
 	public static void toVideo(Video video,YoutubeVideoBriefDTO briefDTO, YoutubeVideoDetailDTO detailDTO) {
@@ -35,7 +35,7 @@ public class VideoConverter {
 		video.setLikeCount(detailDTO.getLikeCount());
 		video.setCommentCount(detailDTO.getCommentCount());
 		video.setVideoCategory(
-			"42".equals(detailDTO.getCategoryId()) ? VideoCategory.SHORT : VideoCategory.LONG
+				VideoCategory.ofId(detailDTO.getCategoryId())
 		);
 	}
 }


### PR DESCRIPTION
(이슈 104번의 PR 확인)

## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)

 enum VideoCategory 유튜브 카테고리값 추가

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)

https://www.googleapis.com/youtube/v3/videoCategories?part=snippet&regionCode=KR&key={구글콘솔키값}
대한민국 기준 유튜브 카테고리 목록 조회 API

위 API 의 응답값을 기준으로 enum 을 추가했습니다.
LLM 서버 아이디어 생성 시, 카테고리 id 값을 기준으로 불러오기 때문에, enum 에 id, title 을 정의했습니다.


## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)

#104 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.