### PR TITLE
[FIX] logs 생성 시 UID 1000 권한으로 생성하게 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,13 @@ RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# 로그 디렉토리 생성
-RUN mkdir -p logs
+# 로그 디렉토리 생성 및 사용자 생성
+RUN groupadd -g 1000 appuser && \
+    useradd -u 1000 -g 1000 -m appuser && \
+    mkdir -p logs && \
+    chown -R 1000:1000 .
+
+USER 1000
 
 # 빌드 결과물 복사
 COPY  ./build/libs/*.jar channeling.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,18 @@ FROM openjdk:17-jdk-slim
 # curl 설치
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-
 # 로그 디렉토리 생성 및 사용자 생성
 RUN groupadd -g 1000 appuser && \
-    useradd -u 1000 -g 1000 -m appuser && \
-    mkdir -p logs && \
-    chown -R 1000:1000 .
+    useradd --no-log-init -u 1000 -g appuser -m appuser && \
+    mkdir -p /app/logs && \
+    chown -R appuser:appuser /app/logs
 
-USER 1000
+USER appuser
+
+WORKDIR /app
 
 # 빌드 결과물 복사
-COPY  ./build/libs/*.jar channeling.jar
+COPY --chown=appuser:appuser ./build/libs/*.jar channeling.jar
 
 # 포트 노출 및 실행
 EXPOSE 8080


### PR DESCRIPTION
## PR 제목
[FIX] logs 생성 시 UID 1000 권한으로 생성하게 수정

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
- logs 폴더 생성 시 root 권한으로 생성, 실제 로그 마운트할 때는 UID 1000으로 마운트 -> 권한 차이로 인한 오류 발생
- logs 폴더 생성 시 UID 1000으로 생성

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#111 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.