### PR TITLE
[FEAT] 로그인시 비디오 풀링 이후에 숏츠 판별 로직 추가

### DIFF
--- a/src/main/java/channeling/be/domain/channel/application/ChannelServiceImpl.java
+++ b/src/main/java/channeling/be/domain/channel/application/ChannelServiceImpl.java
@@ -18,8 +18,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 
 import static channeling.be.response.code.status.ErrorStatus._CHANNEL_NOT_FOUND;
 import static channeling.be.response.code.status.ErrorStatus._CHANNEL_NOT_MEMBER;
@@ -38,6 +42,7 @@ public class ChannelServiceImpl implements ChannelService {
 	private final ChannelRepository channelRepository;
 	private final VideoService videoService;
 	private final RedisUtil redisUtil;
+	private final RestTemplate restTemplate;
 
 	@AllArgsConstructor
 	@Getter
@@ -172,7 +177,48 @@ public class ChannelServiceImpl implements ChannelService {
 		List<YoutubeVideoDetailDTO> videoDetails = YoutubeUtil.getVideoDetailsByIds(
 			accessToken, videoBriefs.stream().map(YoutubeVideoBriefDTO::getVideoId).toList());
 
+		// Shorts 판별 후 categoryId 수정
+		for (int i = 0; i < videoDetails.size(); i++) {
+			String videoId = videoBriefs.get(i).getVideoId();
+
+			if (isYoutubeShorts(videoId)) {
+				videoDetails.get(i).updateCategoryId("42");
+			}
+		}
+
+
+
 		return new YoutubeChannelVideoData(item, videoBriefs, videoDetails);
+	}
+
+	public boolean isYoutubeShorts(String videoId) {
+		String shortsUrl = "https://www.youtube.com/shorts/" + videoId;
+
+		try {
+			ResponseEntity<String> response = restTemplate.exchange(
+				shortsUrl,
+				HttpMethod.HEAD,
+				null,
+				String.class
+			);
+
+			// 2xx 응답이고 리다이렉트가 없으면 Shorts
+			if (response.getStatusCode().is2xxSuccessful()) {
+				return true;
+			}
+
+			// 3xx 리다이렉트면 Location 확인
+			if (response.getStatusCode().is3xxRedirection()) {
+				String location = response.getHeaders().getFirst("Location");
+				return location == null || !location.contains("/watch?v=");
+			}
+
+			return false; // 4xx, 5xx 에러
+
+		} catch (HttpClientErrorException e) {
+			//만약 404 에러일 경우 shorts 가 아니라고 판단
+			return false;
+		}
 	}
 }
 

--- a/src/main/java/channeling/be/global/config/RestTemplateConfig.java
+++ b/src/main/java/channeling/be/global/config/RestTemplateConfig.java
@@ -1,0 +1,31 @@
+package channeling.be.global.config;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+	@Bean
+	public RestTemplate restTemplate(){
+		RestTemplate restTemplate = new RestTemplate();
+
+		SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+		factory.setConnectTimeout(5000);
+		factory.setReadTimeout(5000);
+
+		restTemplate.setRequestFactory(new SimpleClientHttpRequestFactory(){
+			@Override
+			protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
+				super.prepareConnection(connection, httpMethod);
+				connection.setInstanceFollowRedirects(false);		//리다이렉트를 따라가지 않도록 설정(shorts 판별만)
+			}
+		});
+
+		return restTemplate;
+	}
+}

--- a/src/main/java/channeling/be/global/infrastructure/youtube/dto/model/YoutubeVideoDetailDTO.java
+++ b/src/main/java/channeling/be/global/infrastructure/youtube/dto/model/YoutubeVideoDetailDTO.java
@@ -9,8 +9,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public class YoutubeVideoDetailDTO {
 	private final String description;
-	private final String categoryId;
+	private String categoryId;
 	private final Long viewCount;
 	private final Long likeCount;
 	private final Long commentCount;
+
+	public void updateCategoryId(String categoryId){
+		this.categoryId=categoryId;
+	}
 }


### PR DESCRIPTION
## PR 제목
[FEAT] 로그인시 비디오 풀링 이후에 숏츠 판별 로직 추가

## ✨ 변경 유형 (하나 이상 선택)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
로그인시 해당 video id를 포함한 url 요청을 바탕으로 리다이렉트 주소를 확인해 숏츠임을 판별하는 로직 추가

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [x] 코드 컨벤션을 준수했습니다.
- [x] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#156 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.

