### PR TITLE
[FEAT]: CORS 허용 도메인 URL 업데이트

### DIFF
--- a/src/main/java/channeling/be/global/config/SecurityConfig.java
+++ b/src/main/java/channeling/be/global/config/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("https://channeling.it.com", "http://localhost:5173"));
+        configuration.setAllowedOrigins(Arrays.asList("https://chaneling.com", "http://localhost:5173"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## PR 제목
[FEAT]: CORS 허용 도메인 URL 업데이트

## ✨ 변경 유형 (하나 이상 선택)
- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [ ] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [ ] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
CORS 설정에서 허용되는 도메인 URL을 `https://channeling.it.com`에서 `https://chaneling.com`으로 변경
서비스 도메인 변경에 따라 보안 설정을 업데이트

## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
#246

## 💬 기타 (선택 사항)