### PR TITLE
[FIX] 유튜브 채널 미연결 사용자 로그인 실패 처리

### DIFF
--- a/src/main/java/channeling/be/domain/auth/handler/Oauth2LoginSuccessHandler.java
+++ b/src/main/java/channeling/be/domain/auth/handler/Oauth2LoginSuccessHandler.java
@@ -6,6 +6,7 @@ import channeling.be.domain.auth.application.MemberOauth2UserService.LoginResult
 import channeling.be.domain.channel.application.ChannelSyncService;
 import channeling.be.domain.idea.application.IdeaService;
 import channeling.be.global.infrastructure.jwt.JwtUtil;
+import channeling.be.response.exception.handler.YoutubeHandler;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -73,7 +74,20 @@ public class Oauth2LoginSuccessHandler implements AuthenticationSuccessHandler {
          * ------------------------------------------------- */
 
         long loginStartTime = System.currentTimeMillis();
-        LoginResult result = memberOauth2UserService.executeGoogleLoginFast(attrs, googleAccessToken);
+        LoginResult result;
+        try {
+            result = memberOauth2UserService.executeGoogleLoginFast(attrs, googleAccessToken);
+        } catch (YoutubeHandler e) {
+            log.warn("채널 없는 계정 로그인 시도 - error: {}", e.getCode());
+            String targetUrl = UriComponentsBuilder.fromUriString(frontUrl + "/auth/callback")
+                    .queryParam("token", "")
+                    .queryParam("message", "Fail")
+                    .queryParam("error", "NO_CHANNEL")
+                    .build()
+                    .toUriString();
+            response.sendRedirect(targetUrl);
+            return;
+        }
         long loginEndTime = System.currentTimeMillis();
         log.info("[TIME] executeGoogleLoginFast (멤버/채널 처리): {}ms | 신규사용자: {}",
                 loginEndTime - loginStartTime, result.isNew());

--- a/src/main/java/channeling/be/global/infrastructure/youtube/YoutubeUtil.java
+++ b/src/main/java/channeling/be/global/infrastructure/youtube/YoutubeUtil.java
@@ -47,7 +47,13 @@ public class YoutubeUtil {
             String response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString()).body();
             log.info("Response: {}", response);
             YoutubeChannelResDTO youtubeResponse = mapper.readValue(response, YoutubeChannelResDTO.class);
+            if (youtubeResponse.getItems() == null || youtubeResponse.getItems().isEmpty()) {
+                log.warn("유튜브 채널이 없는 계정으로 로그인 시도");
+                throw new YoutubeHandler(ErrorStatus._YOUTUBE_CHANNEL_NOT_FOUND);
+            }
             return youtubeResponse.getItems().get(0); // 채널 정보가 담긴 첫 번째 아이템 반환
+        } catch (YoutubeHandler e) {
+            throw e;
         } catch (Exception e) {
             log.error("🚨 YouTube 채널 정보 조회 실패 - 오류: {}", e.getMessage(), e);
             throw new RuntimeException("Failed to fetch channel details: " + e.getMessage(), e);

--- a/src/main/java/channeling/be/response/code/status/ErrorStatus.java
+++ b/src/main/java/channeling/be/response/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //유튜브 관련 에러
     _YOUTUBE_PLAYLIST_PULLING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "YOUTUBE500", "유튜브 플레이리스트를 가져오는 중 에러가 발생했습니다."),
+    _YOUTUBE_CHANNEL_NOT_FOUND(HttpStatus.BAD_REQUEST, "YOUTUBE402", "연결된 유튜브 채널이 없습니다. 유튜브 채널을 먼저 생성해주세요."),
     _LINK_NOT_VALID(HttpStatus.BAD_REQUEST, "YOUTUBE400", "유효하지 않은 유튜브 URL 입니다"),
 
     //채널 관련 에러


### PR DESCRIPTION
유튜브 채널이 없는 계정으로 구글 OAuth2 로그인을 시도할 때 발생하는 오류를 명확하게 처리한다
`YoutubeUtil`에서 유튜브 채널이 없는 경우 `_YOUTUBE_CHANNEL_NOT_FOUND` 예외를 발생시킨다
`Oauth2LoginSuccessHandler`에서 이 예외를 catch하여 프론트엔드로 `NO_CHANNEL` 오류와 함께 리다이렉트한다
사용자에게 채널 미연결 상황을 정확히 알려 불편을 해소한다

+저장한 멤버도 롤백해서 db에 저장 안 되게 함

<img width="1198" height="714" alt="image" src="https://github.com/user-attachments/assets/e0ece754-9a32-4367-a477-e04d79ac2266" />

