### PR TITLE
-reset- [REFACTOR] 리포트 생성 아키텍처를 Kafka 기반 비동기 구조로 리팩토링(A파트)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     // Flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/channeling/be/domain/report/application/ReportKafkaMessage.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportKafkaMessage.java
@@ -1,0 +1,30 @@
+package channeling.be.domain.report.application;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class
+ReportKafkaMessage {
+
+    @JsonProperty("task_id")
+    private Long taskId;
+
+    @JsonProperty("report_id")
+    private Long reportId;
+
+    @JsonProperty("step")
+    private String step;
+
+    @JsonProperty("google_access_token")
+    private String googleAccessToken;
+
+    @JsonProperty("skip_vector_save")
+    private boolean skipVectorSave;
+}

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -27,8 +27,6 @@ import channeling.be.response.exception.handler.ChannelHandler;
 import channeling.be.response.exception.handler.ReportHandler;
 import channeling.be.response.exception.handler.TaskHandler;
 import channeling.be.response.exception.handler.VideoHandler;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,19 +34,12 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -64,10 +55,13 @@ public class ReportServiceImpl implements ReportService {
     private final ReportDeleteService reportDeleteService;
     private final ChannelRepository channelRepository;
     private final ReportLogRepository reportLogRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    //환경변수에서 FASTAPI_URL 환경변수 불러오기
-    @Value("${FASTAPI_URL:http://localhost:8000}")
-    private String baseFastApiUrl;
+    @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
+    private String overviewTopic;
+
+    @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
+    private String analysisTopic;
 
     @Override
     @Transactional(readOnly = true)
@@ -154,6 +148,7 @@ public class ReportServiceImpl implements ReportService {
     }
 
     @Override
+    @Transactional
     public ReportResDto.createReport createReport(Member member, Long videoId) {
 
         // Redis를 이용한 중복 클릭(Race Condition) 방지 (5초 락)
@@ -169,15 +164,15 @@ public class ReportServiceImpl implements ReportService {
 
             // 요청 영상 존재 여부 확인
             if (!videoRepository.existsById(videoId)) {
-                throw new VideoHandler(ErrorStatus._VIDEO_NOT_FOUND) ;
+                throw new VideoHandler(ErrorStatus._VIDEO_NOT_FOUND);
             }
 
             // 요청 영상의 주인인지 확인
             Video video = videoRepository.findByIdWithMemberId(videoId, member.getId())
                     .orElseThrow(() -> new VideoHandler(ErrorStatus._VIDEO_NOT_MEMBER));
 
-            // 멤버와 영상으로 기존에 분S석했던 리포트가 존재하는 지 조회
-            Optional<Report> optionalReport  = reportRepository.findByVideoAndMember(video.getId(), member.getId());
+            // 멤버와 영상으로 기존에 분석했던 리포트가 존재하는 지 조회
+            Optional<Report> optionalReport = reportRepository.findByVideoAndMember(video.getId(), member.getId());
 
             // 기존 리포트 존재 시 (1) 현재 생성 중 여부 확인 (2) 삭제
             optionalReport.ifPresent(report -> {
@@ -187,59 +182,45 @@ public class ReportServiceImpl implements ReportService {
 
             // redis에서 구글 토큰 가져오기 -> 2분 보다 적으면 에러 반환
             Long ttl = redisUtil.getGoogleAccessTokenExpire(member.getId());
-            log.info("리포트 분석 전, 구글 토큰 TTL (초): {}" , ttl);
+            log.info("리포트 분석 전, 구글 토큰 TTL (초): {}", ttl);
             if (ttl <= 120) {
                 throw new ReportHandler(ErrorStatus._TOKEN_EXPIRED);
             }
             String googleAccessToken = redisUtil.getGoogleAccessToken(member.getId());
 
-            // fastapi 쪽에 요청 보내기
-            Long taskId = sendPostToFastAPI(videoId, googleAccessToken);
-            // taskId로 리포트 조회
-            Report report = reportRepository.findByTaskId(taskId)
-                    .orElseThrow(() -> new ReportHandler(ErrorStatus._REPORT_NOT_CREATE));
+            // Report, Task 생성 (DB 소유권 Spring)
+            Report report = reportRepository.save(Report.builder().video(video).build());
+            Task task = taskRepository.save(Task.builder()
+                    .report(report)
+                    .overviewStatus(TaskStatus.PENDING)
+                    .analysisStatus(TaskStatus.PENDING)
+                    .ideaStatus(TaskStatus.COMPLETED)
+                    .build());
+
+            // Kafka 메시지 발행 (기존 V2 토픽 사용)
+            ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
+                    .taskId(task.getId())
+                    .reportId(report.getId())
+                    .step("overview")
+                    .googleAccessToken(googleAccessToken)
+                    .skipVectorSave(true)
+                    .build();
+
+            ReportKafkaMessage analysisMessage = ReportKafkaMessage.builder()
+                    .taskId(task.getId())
+                    .reportId(report.getId())
+                    .step("analysis")
+                    .googleAccessToken(googleAccessToken)
+                    .skipVectorSave(true)
+                    .build();
+
+            kafkaTemplate.send(overviewTopic, overviewMessage);
+            kafkaTemplate.send(analysisTopic, analysisMessage);
+            log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", report.getId(), task.getId());
 
             return new ReportResDto.createReport(report.getId(), video.getId());
         } finally {
             redisUtil.deleteData(lockKey);
-        }
-    }
-
-    private Long sendPostToFastAPI(Long videoId, String googleAccessToken) {
-//
-        // HTTP 요청 보내기
-        RestTemplate restTemplate = new RestTemplate();
-        // url 설정
-        String url = UriComponentsBuilder
-                .fromHttpUrl(baseFastApiUrl+"/reports/v2")
-                .queryParam("video_id", videoId)
-                .toUriString();
-
-        // requestbody 생성
-        Map<String, String> requestBody = new HashMap<>();
-        requestBody.put("googleAccessToken", googleAccessToken);
-
-        // 헤더 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        // 요청 생성
-        HttpEntity<Map<String, String>> request = new HttpEntity<>(requestBody, headers);
-        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
-
-        // 응답 파싱 및 반환
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode root = objectMapper.readTree(response.getBody());
-
-            JsonNode resultNode = root.get("result");
-            if (resultNode != null && resultNode.has("task_id")) {
-                return resultNode.get("task_id").asLong();
-            } else {
-                throw new IllegalStateException("응답에 id가 없습니다.");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("FastAPI 응답 파싱 실패", e);
         }
     }
 

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -191,7 +191,7 @@ public class ReportServiceImpl implements ReportService {
                     .build());
 
             // Kafka 메시지 발행 — 트랜잭션 커밋 후 전송
-            kafkaMessageProducer.sendReportMessagesAfterCommit(task.getId(), report.getId(), googleAccessToken);
+            kafkaMessageProducer.sendReportMessagesAfterCommit(task.getId(), report.getId(), googleAccessToken, member.getId());
 
             return new ReportResDto.createReport(report.getId(), video.getId());
         } finally {

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -21,6 +21,7 @@ import channeling.be.domain.video.domain.Video;
 import channeling.be.domain.video.domain.VideoCategory;
 import channeling.be.domain.video.domain.VideoType;
 import channeling.be.domain.video.domain.repository.VideoRepository;
+import channeling.be.global.infrastructure.kafka.KafkaMessageProducer;
 import channeling.be.global.infrastructure.redis.RedisUtil;
 import channeling.be.response.code.status.ErrorStatus;
 import channeling.be.response.exception.handler.ChannelHandler;
@@ -29,12 +30,10 @@ import channeling.be.response.exception.handler.TaskHandler;
 import channeling.be.response.exception.handler.VideoHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,13 +54,7 @@ public class ReportServiceImpl implements ReportService {
     private final ReportDeleteService reportDeleteService;
     private final ChannelRepository channelRepository;
     private final ReportLogRepository reportLogRepository;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
-
-    @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
-    private String overviewTopic;
-
-    @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
-    private String analysisTopic;
+    private final KafkaMessageProducer kafkaMessageProducer;
 
     @Override
     @Transactional(readOnly = true)
@@ -197,26 +190,8 @@ public class ReportServiceImpl implements ReportService {
                     .ideaStatus(TaskStatus.COMPLETED)
                     .build());
 
-            // Kafka 메시지 발행 (기존 V2 토픽 사용)
-            ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
-                    .taskId(task.getId())
-                    .reportId(report.getId())
-                    .step("overview")
-                    .googleAccessToken(googleAccessToken)
-                    .skipVectorSave(true)
-                    .build();
-
-            ReportKafkaMessage analysisMessage = ReportKafkaMessage.builder()
-                    .taskId(task.getId())
-                    .reportId(report.getId())
-                    .step("analysis")
-                    .googleAccessToken(googleAccessToken)
-                    .skipVectorSave(true)
-                    .build();
-
-            kafkaTemplate.send(overviewTopic, overviewMessage);
-            kafkaTemplate.send(analysisTopic, analysisMessage);
-            log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", report.getId(), task.getId());
+            // Kafka 메시지 발행 — 트랜잭션 커밋 후 전송
+            kafkaMessageProducer.sendReportMessagesAfterCommit(task.getId(), report.getId(), googleAccessToken);
 
             return new ReportResDto.createReport(report.getId(), video.getId());
         } finally {

--- a/src/main/java/channeling/be/domain/report/domain/ReportStep.java
+++ b/src/main/java/channeling/be/domain/report/domain/ReportStep.java
@@ -1,0 +1,19 @@
+package channeling.be.domain.report.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ReportStep {
+    OVERVIEW("overview"),
+    ANALYSIS("analysis");
+
+    private final String value;
+
+    ReportStep(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/channeling/be/domain/task/domain/Task.java
+++ b/src/main/java/channeling/be/domain/task/domain/Task.java
@@ -34,4 +34,12 @@ public class Task extends BaseEntity {
     public void setReport(Report report) {
         this.report = report;
     }
+
+    public void failOverview() {
+        this.overviewStatus = TaskStatus.FAILED;
+    }
+
+    public void failAnalysis() {
+        this.analysisStatus = TaskStatus.FAILED;
+    }
 }

--- a/src/main/java/channeling/be/domain/task/domain/Task.java
+++ b/src/main/java/channeling/be/domain/task/domain/Task.java
@@ -35,11 +35,4 @@ public class Task extends BaseEntity {
         this.report = report;
     }
 
-    public void failOverview() {
-        this.overviewStatus = TaskStatus.FAILED;
-    }
-
-    public void failAnalysis() {
-        this.analysisStatus = TaskStatus.FAILED;
-    }
 }

--- a/src/main/java/channeling/be/domain/task/domain/repository/TaskRepository.java
+++ b/src/main/java/channeling/be/domain/task/domain/repository/TaskRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -34,4 +36,14 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Task t WHERE t.report.id IN :reportIds")
     void deleteAllByReportIdIn(@Param("reportIds") List<Long> reportIds);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Task t SET t.overviewStatus = 'FAILED' WHERE t.id = :id")
+    void failOverviewStatus(@Param("id") Long id);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Task t SET t.analysisStatus = 'FAILED' WHERE t.id = :id")
+    void failAnalysisStatus(@Param("id") Long id);
 }

--- a/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
+++ b/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
@@ -1,0 +1,37 @@
+package channeling.be.global.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        // FastAPI JSON 역직렬화 호환을 위해 Spring 타입 헤더 비활성화
+        config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
+++ b/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
@@ -12,7 +12,6 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
-
 @Configuration
 public class KafkaProducerConfig {
 
@@ -22,11 +21,30 @@ public class KafkaProducerConfig {
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> config = new HashMap<>();
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        // FastAPI JSON 역직렬화 호환을 위해 Spring 타입 헤더 비활성화
-        config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+
+        // ── 기본 설정 ──────────────────────────────────────────
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);           // Kafka 브로커 초기 접속 주소
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);  // Key를 String → byte[] 변환
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);  // Value를 Object → JSON byte[] 변환
+
+        // ── acks 설정 ───────────────────────────────────────────
+        config.put(ProducerConfig.ACKS_CONFIG, "all");                                   // 리더 + 모든 ISR 저장 확인 후 ack
+
+        // ── retries 설정 ────────────────────────────────────────
+        config.put(ProducerConfig.RETRIES_CONFIG, 3);                                    // 전송 실패 시 최대 3회 재시도
+        config.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 1000);                        // 재시도 간격 1초
+        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 120000);                   // send()부터 최종 ack까지 최대 2분
+        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);                     // 단일 전송 요청 타임아웃 30초
+        config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);                      // 중복 방지 + 재시도 시 순서 보장
+
+        // ── compression 설정 ────────────────────────────────────
+        config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");                    // 배치 단위 압축 (속도/압축률 균형)
+
+        // ── 배치/버퍼 설정 (선택) ────────────────────────────────
+        config.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);                             // 파티션당 배치 크기 16KB
+        config.put(ProducerConfig.LINGER_MS_CONFIG, 5);                                  // 배치 미달 시 최대 5ms 대기 후 전송
+        config.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);                       // 미전송 메시지 대기 버퍼 32MB
+
         return new DefaultKafkaProducerFactory<>(config);
     }
 

--- a/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
@@ -1,0 +1,17 @@
+package channeling.be.global.infrastructure.kafka;
+
+import channeling.be.global.infrastructure.kafka.dto.ReportKafkaEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageProducer {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void sendReportMessagesAfterCommit(Long taskId, Long reportId, String googleAccessToken) {
+        eventPublisher.publishEvent(new ReportKafkaEvent(taskId, reportId, googleAccessToken));
+    }
+}

--- a/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
@@ -11,7 +11,7 @@ public class KafkaMessageProducer {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public void sendReportMessagesAfterCommit(Long taskId, Long reportId, String googleAccessToken) {
-        eventPublisher.publishEvent(new ReportKafkaEvent(taskId, reportId, googleAccessToken));
+    public void sendReportMessagesAfterCommit(Long taskId, Long reportId, String googleAccessToken, Long userId) {
+        eventPublisher.publishEvent(new ReportKafkaEvent(taskId, reportId, googleAccessToken, userId));
     }
 }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -4,6 +4,7 @@ import channeling.be.domain.report.domain.ReportStep;
 import channeling.be.domain.task.domain.repository.TaskRepository;
 import channeling.be.global.infrastructure.kafka.dto.ReportKafkaEvent;
 import channeling.be.global.infrastructure.kafka.dto.ReportKafkaMessage;
+import channeling.be.global.infrastructure.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +20,7 @@ public class ReportKafkaEventListener {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final TaskRepository taskRepository;
+    private final RedisUtil redisUtil;
 
     @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
     private String overviewTopic;
@@ -44,22 +46,24 @@ public class ReportKafkaEventListener {
                 .skipVectorSave(true)
                 .build();
 
-        sendWithFailureHandling(overviewTopic, overviewMessage, event.taskId(), ReportStep.OVERVIEW);
-        sendWithFailureHandling(analysisTopic, analysisMessage, event.taskId(), ReportStep.ANALYSIS);
-        log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
+        sendWithFailureHandling(overviewTopic, overviewMessage, event.taskId(), ReportStep.OVERVIEW, event.userId());
+        sendWithFailureHandling(analysisTopic, analysisMessage, event.taskId(), ReportStep.ANALYSIS, event.userId());
+        log.info("Kafka 메시지 발행 요청 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
     }
 
-    private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step) {
+    private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step, Long userId) {
         kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
             if (ex != null) {
-                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}, error: {}", topic, taskId, step, ex.getMessage());
-                taskRepository.findById(taskId).ifPresent(task -> {
+                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}", topic, taskId, step, ex);
+                try {
                     switch (step) {
-                        case OVERVIEW -> task.failOverview();
-                        case ANALYSIS -> task.failAnalysis();
+                        case OVERVIEW -> taskRepository.failOverviewStatus(taskId);
+                        case ANALYSIS -> taskRepository.failAnalysisStatus(taskId);
                     }
-                    taskRepository.save(task);
-                });
+                    redisUtil.publishFailure(userId, step.getValue());
+                } catch (Exception e) {
+                    log.error("Kafka 전송 실패 후처리 중 오류 - taskId: {}, step: {}", taskId, step, e);
+                }
             }
         });
     }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -28,6 +29,7 @@ public class ReportKafkaEventListener {
     @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
     private String analysisTopic;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReportKafkaEvent(ReportKafkaEvent event) {
         ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
@@ -52,19 +54,27 @@ public class ReportKafkaEventListener {
     }
 
     private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step, Long userId) {
-        kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
-            if (ex != null) {
-                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}", topic, taskId, step, ex);
-                try {
-                    switch (step) {
-                        case OVERVIEW -> taskRepository.failOverviewStatus(taskId);
-                        case ANALYSIS -> taskRepository.failAnalysisStatus(taskId);
-                    }
-                    redisUtil.publishFailure(userId, step.getValue());
-                } catch (Exception e) {
-                    log.error("Kafka 전송 실패 후처리 중 오류 - taskId: {}, step: {}", taskId, step, e);
+        try {
+            kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
+                if (ex != null) {
+                    handleFailure(topic, taskId, step, userId, ex);
                 }
+            });
+        } catch (Exception ex) {
+            handleFailure(topic, taskId, step, userId, ex);
+        }
+    }
+
+    private void handleFailure(String topic, Long taskId, ReportStep step, Long userId, Throwable ex) {
+        log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}", topic, taskId, step, ex);
+        try {
+            switch (step) {
+                case OVERVIEW -> taskRepository.failOverviewStatus(taskId);
+                case ANALYSIS -> taskRepository.failAnalysisStatus(taskId);
             }
-        });
+            redisUtil.publishFailure(userId, step.getValue());
+        } catch (Exception e) {
+            log.error("Kafka 전송 실패 후처리 중 오류 - taskId: {}, step: {}", taskId, step, e);
+        }
     }
 }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -1,0 +1,66 @@
+package channeling.be.global.infrastructure.kafka;
+
+import channeling.be.domain.report.domain.ReportStep;
+import channeling.be.domain.task.domain.repository.TaskRepository;
+import channeling.be.global.infrastructure.kafka.dto.ReportKafkaEvent;
+import channeling.be.global.infrastructure.kafka.dto.ReportKafkaMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReportKafkaEventListener {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final TaskRepository taskRepository;
+
+    @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
+    private String overviewTopic;
+
+    @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
+    private String analysisTopic;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReportKafkaEvent(ReportKafkaEvent event) {
+        ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
+                .taskId(event.taskId())
+                .reportId(event.reportId())
+                .step(ReportStep.OVERVIEW)
+                .googleAccessToken(event.googleAccessToken())
+                .skipVectorSave(true)
+                .build();
+
+        ReportKafkaMessage analysisMessage = ReportKafkaMessage.builder()
+                .taskId(event.taskId())
+                .reportId(event.reportId())
+                .step(ReportStep.ANALYSIS)
+                .googleAccessToken(event.googleAccessToken())
+                .skipVectorSave(true)
+                .build();
+
+        sendWithFailureHandling(overviewTopic, overviewMessage, event.taskId(), ReportStep.OVERVIEW);
+        sendWithFailureHandling(analysisTopic, analysisMessage, event.taskId(), ReportStep.ANALYSIS);
+        log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
+    }
+
+    private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step) {
+        kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}, error: {}", topic, taskId, step, ex.getMessage());
+                taskRepository.findById(taskId).ifPresent(task -> {
+                    switch (step) {
+                        case OVERVIEW -> task.failOverview();
+                        case ANALYSIS -> task.failAnalysis();
+                    }
+                    taskRepository.save(task);
+                });
+            }
+        });
+    }
+}

--- a/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
@@ -1,0 +1,8 @@
+package channeling.be.global.infrastructure.kafka.dto;
+
+public record ReportKafkaEvent(
+        Long taskId,
+        Long reportId,
+        String googleAccessToken
+) {
+}

--- a/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
@@ -3,6 +3,7 @@ package channeling.be.global.infrastructure.kafka.dto;
 public record ReportKafkaEvent(
         Long taskId,
         Long reportId,
-        String googleAccessToken
+        String googleAccessToken,
+        Long userId
 ) {
 }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaMessage.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaMessage.java
@@ -1,5 +1,6 @@
-package channeling.be.domain.report.application;
+package channeling.be.global.infrastructure.kafka.dto;
 
+import channeling.be.domain.report.domain.ReportStep;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,8 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class
-ReportKafkaMessage {
+public class ReportKafkaMessage {
 
     @JsonProperty("task_id")
     private Long taskId;
@@ -20,7 +20,7 @@ ReportKafkaMessage {
     private Long reportId;
 
     @JsonProperty("step")
-    private String step;
+    private ReportStep step;
 
     @JsonProperty("google_access_token")
     private String googleAccessToken;

--- a/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
+++ b/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
@@ -1,12 +1,15 @@
 package channeling.be.global.infrastructure.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -14,10 +17,12 @@ import java.util.concurrent.TimeUnit;
  *    - 문자열(String) 타입 전용 StringRedisTemplate을 주입받아 사용
  *    - 기본 CRUD + 만료시간 설정 기능 제공
  */
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class RedisUtil {
     private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
 
     /** redis에 저장하는 구글 엑세스의 지속 시간 **/
     @Value("${jwt.google.access.expiration}")
@@ -142,5 +147,24 @@ public class RedisUtil {
                 String.valueOf(1),
                 Duration.ofSeconds(accessExpiration)
         );
+    }
+
+    // ── Redis Pub/Sub ──────────────────────────────────
+
+    private static final String COMPLETE_CHANNEL = "complete";
+
+    public void publishFailure(Long userId, String step) {
+        try {
+            String innerMessage = objectMapper.writeValueAsString(
+                    Map.of("status", "fail", "step", step)
+            );
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("userId", String.valueOf(userId), "message", innerMessage)
+            );
+            stringRedisTemplate.convertAndSend(COMPLETE_CHANNEL, payload);
+            log.info("Redis 실패 알림 발행 - userId: {}, step: {}", userId, step);
+        } catch (Exception e) {
+            log.error("Redis Publish 실패 - userId: {}, step: {}", userId, step, e);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,5 @@ spring:
     name: channeling-be
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:db,s3,oauth,jwt}
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}


### PR DESCRIPTION
## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)

리팩토링 A 파트

## ✨ 변경 유형 (하나 이상 선택)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [x] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 업데이트 (주석, README 등)
- [x] Chore: 기타 변경 (빌드 설정, 라이브러리 업데이트 등)
- [ ] Test: 테스트 코드 추가/수정

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)

- 관련문서 : 스터디 24주차, 채널링 20주차 노션 확인
- https://github.com/channeling-ai/LLM/pull/191

  - 리포트 생성 시 FastAPI 동기 HTTP 호출(RestTemplate)을 제거하고, Kafka 메시지 발행 기반 비동기 아키텍처로 전환                                                                                          
  - Report/Task 엔티티의 DB 소유권을 Spring으로 이관하여, 트랜잭션 커밋 후 Kafka 토픽(overview, analysis)에 메시지 발행
  - Kafka 발행 실패 시 Task 상태를 FAILED로 업데이트하고, Redis Pub/Sub으로 클라이언트에 실패 알림 전송하는 fallback 처리 추가                                                                             

  - ReportServiceImpl: FastAPI RestTemplate 호출 제거 → Report/Task를 직접 생성 후 KafkaMessageProducer를 통해 메시지 발행                                                                                 
  - @Transactional + @TransactionalEventListener(AFTER_COMMIT) 패턴으로 DB 커밋 보장 후 Kafka 전송
 
## ⚙️ 주요 작업 (선택 사항)
- [ ] 새로운 API 추가 (API 명세서 링크 또는 간단한 정보)
- [ ] 데이터베이스 스키마 변경 (변경 내용 명시)
- [ ] 외부 라이브러리 추가/제거 (라이브러리 명시)

<img width="950" height="648" alt="image" src="https://github.com/user-attachments/assets/d75a0204-b7b1-47d2-b7ae-1d026e74a104" />
<img width="950" height="570" alt="image" src="https://github.com/user-attachments/assets/f0a9be28-a430-45a9-8bca-725af70ea5c7" />
<img width="1475" height="298" alt="image" src="https://github.com/user-attachments/assets/a8b6d7ac-c023-48b6-8349-1b9682e05e95" />

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다.
- [ ] 변경 사항에 대한 문서 업데이트가 필요한 경우 반영했습니다.

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)

- #298 

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.