### PR TITLE
[REFACTOR] 카프카 프로듀서 설정 수정 및 트랜잭션 프로듀서 적용 [A파트]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ dependencies {
     // Flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/docs/2026-03-23-kafka-settings-guide.md
+++ b/docs/2026-03-23-kafka-settings-guide.md
@@ -1,0 +1,242 @@
+# Channeling Kafka BE->LLM [A파트 정리]
+
+> 작성일: 2026-03-23
+> 대상: BE / LLM 팀 전체
+> 관련 브랜치: refactor/#300-kafka-producer-setting
+
+---
+
+## 메시지 흐름
+
+```
+[Spring BE] ──── overview-topic-v2 ────→ [FastAPI LLM]
+            ──── analysis-topic-v2 ───→
+```
+
+- 두 토픽은 하나의 Kafka 트랜잭션으로 묶여 원자적으로 발행됨
+- 둘 다 성공하거나 둘 다 abort됨
+
+---
+
+## 프로듀서 (Spring BE)
+
+### 1. acks
+
+| 설정 | 값 | 의미 |
+|------|----|------|
+| `acks` | `all` | 리더 + 모든 ISR 복제본이 저장을 확인해야 ack 반환 |
+
+> 트랜잭셔널 프로듀서는 `acks=all`이 강제 적용된다. 다른 값으로 변경 불가.
+
+### 2. 파티션 전략
+
+| 항목 | 현재 설정 |
+|------|----------|
+| 메시지 key | **미지정** (null) |
+| 파티셔너 | DefaultPartitioner → key가 null이면 **RoundRobin** |
+| 파티션 수 | 1 (환경변수 `KAFKA_TOPIC_PARTITIONS`로 변경 가능) |
+
+**현재 파티션 1개이므로 순서 보장됨.** 파티션을 늘릴 경우:
+- key가 null이면 RoundRobin으로 분산 → **메시지 순서 보장 안 됨**
+- 순서가 필요하면 `report_id`를 key로 지정하여 같은 리포트의 메시지를 같은 파티션으로 라우팅해야 함
+
+### 3. 재시도
+
+| 설정 | 값 | 설명 |
+|------|----|------|
+| `retries` | `Integer.MAX_VALUE` | 트랜잭셔널 프로듀서 기본값 (무한 재시도) |
+| `retry.backoff.ms` | `1000` | 재시도 간격 1초 |
+| `delivery.timeout.ms` | `10000` | send()~최종 ack까지 최대 10초 |
+| `request.timeout.ms` | `5000` | 단일 전송 요청 타임아웃 |
+
+**재시도 동작 방식:**
+```
+send 시도 → 실패 → 1초 대기 → 재시도 → 실패 → 1초 대기 → ...
+└── 이 전체 과정이 delivery.timeout.ms(10초) 이내에 끝나야 함
+└── 10초 초과 시 TimeoutException → 트랜잭션 abort
+```
+
+실질적으로 `(10000 - 5000) / 1000 ≈ 4~5회` 재시도 가능.
+
+### 4. 멱등성 (Idempotent Producer)
+
+| 설정 | 값 | 설명 |
+|------|----|------|
+| `enable.idempotence` | `true` | 트랜잭셔널 프로듀서 기본값 (강제) |
+| `max.in.flight.requests.per.connection` | `5` | 멱등성 보장 범위 내 최대 동시 요청 |
+
+**멱등성이란:** 네트워크 오류로 재시도 시 브로커가 중복 메시지를 자동 감지·폐기한다.
+- 프로듀서가 각 메시지에 `PID(Producer ID) + Sequence Number`를 부여
+- 브로커가 이미 저장된 시퀀스와 비교하여 중복 차단
+- 재시도로 인한 순서 역전도 방지 (시퀀스 기반 정렬)
+
+### 5. 트랜잭션
+
+| 항목 | 값 |
+|------|----|
+| `transactional.id` prefix | `channeling-be-tx-` |
+| 실제 ID | `channeling-be-tx-{인스턴스별 고유 suffix}` (Spring Kafka가 자동 부여) |
+
+**트랜잭션 범위:**
+```
+executeInTransaction() {
+    send(overview-topic-v2, message)   ← 트랜잭션에 포함
+    send(analysis-topic-v2, message)   ← 트랜잭션에 포함
+}
+// → 두 send 모두 성공 시 commit, 하나라도 실패 시 abort
+```
+
+**트랜잭션이 보장하는 것:**
+- 두 토픽의 메시지가 **모두 보이거나 모두 안 보임** (컨슈머가 `read_committed`일 때)
+- abort된 메시지는 `read_committed` 컨슈머에게 노출되지 않음
+
+**트랜잭션이 보장하지 않는 것:**
+- DB 트랜잭션과의 연동 (DB 커밋 후 Kafka 발행이 실패할 수 있음)
+- 현재는 DB 커밋 후(`AFTER_COMMIT`) Kafka 발행하므로, Kafka 실패 시 Redis fallback으로 처리
+
+---
+
+## 컨슈머 (FastAPI LLM)
+
+### 1. group.id
+
+| 설정 | 값 |
+|------|----|
+| `group.id` | `llm-service-group` |
+
+같은 group.id의 컨슈머끼리 파티션을 분배받아 메시지를 나눠 처리한다.
+현재 파티션 1개이므로 같은 그룹 내 컨슈머 1개만 활성 소비한다.
+
+### 2. isolation.level (트랜잭셔널 프로듀서 대응)
+
+| 설정 | 값 | 필수 여부 |
+|------|----|----------|
+| `isolation_level` | `read_committed` | **필수** |
+
+```python
+@self.broker.subscriber(
+    topic,
+    isolation_level="read_committed",
+    ...
+)
+```
+
+| isolation.level | 동작 | 위험 |
+|----------------|------|------|
+| `read_uncommitted` (기본값) | abort된 트랜잭션 메시지도 소비 | **처리하면 안 되는 메시지를 처리할 수 있음** |
+| `read_committed` | commit된 트랜잭션 메시지만 소비 | 없음 (정상) |
+
+> **BE가 트랜잭셔널 프로듀서를 사용하므로 LLM 컨슈머는 반드시 `read_committed`를 설정해야 한다.**
+
+### 3. 신뢰성 설정 (프로듀서 acks와의 쌍)
+
+프로듀서 `acks=all`과 컨슈머 `isolation_level=read_committed`가 쌍으로 동작한다:
+
+```
+프로듀서 acks=all  →  모든 ISR에 저장된 후에만 ack
+                      ↓
+브로커              →  트랜잭션 commit 마커 기록
+                      ↓
+컨슈머 read_committed → commit 마커가 있는 메시지만 소비
+```
+
+이 조합이 **메시지 유실 없이 정확한 전달**을 보장한다.
+
+### 4. 오프셋 관리
+
+| 설정 | 값 | 설명 |
+|------|----|------|
+| `auto_commit` | `True` | 5초 간격 자동 커밋 |
+| `auto_commit_interval_ms` | `5000` | 커밋 주기 |
+| `auto_offset_reset` | `earliest` | 오프셋 없을 때 처음부터 읽기 |
+
+**auto_offset_reset 선택지:**
+
+| 값 | 동작 | 적합한 경우 |
+|----|------|------------|
+| `earliest` | 토픽의 가장 오래된 메시지부터 | 메시지 유실 방지 우선 (현재 설정) |
+| `latest` | 구독 시점 이후 메시지만 | 실시간 처리만 필요할 때 |
+
+**auto_commit=True의 트레이드오프:**
+- 처리 중 크래시 시 → 오프셋이 이미 커밋되었으면 메시지 유실 가능
+- 현재는 의도적 선택: LLM 처리 실패 시 Redis pub/sub으로 별도 알림하므로 재처리보다 빠른 실패 알림 우선
+
+### 5. 성능 튜닝
+
+**프로듀서 측 (BE):**
+
+| 설정 | 값 | 역할 |
+|------|----|------|
+| `compression.type` | `snappy` | 배치 단위 압축 (LLM에 `python-snappy` 필요) |
+| `batch.size` | `16384` (16KB) | 파티션당 배치 크기 |
+| `linger.ms` | `5` | 배치 채우기 위한 최대 대기 시간 |
+| `buffer.memory` | `33554432` (32MB) | 미전송 메시지 버퍼 |
+
+**컨슈머 측 (LLM):**
+
+| 설정 | 현재 값 | 비고 |
+|------|---------|------|
+| `auto_commit_interval_ms` | `5000` | FastStream 기본값 사용 |
+
+> 현재 메시지 볼륨이 낮아 (리포트 생성 요청 단위) 별도 컨슈머 성능 튜닝 불필요.
+> 볼륨 증가 시 `max.poll.records`, `fetch.min.bytes` 등 조정 검토.
+
+### 6. 파티션 전략
+
+| 항목 | 현재 상태 |
+|------|----------|
+| 파티션 수 | 1개 (토픽당) |
+| 컨슈머 수 | 1개 (llm-service-group 내) |
+| 파티션 할당 | 자동 (1:1 매핑) |
+
+**스케일 아웃 시나리오:**
+
+| 파티션 수 | 컨슈머 수 | 동작 |
+|----------|----------|------|
+| 1 | 1 | 현재 상태. 순서 보장됨 |
+| 1 | 2+ | 1개만 활성 소비, 나머지 대기 (의미 없음) |
+| N | N | 파티션별 1 컨슈머. 병렬 처리 가능 |
+| N | N 초과 | 초과분 유휴 상태 |
+
+> 파티션 확장 시 프로듀서에 메시지 key(`report_id`) 지정 필요. 미지정 시 RoundRobin으로 같은 리포트의 overview/analysis가 다른 파티션으로 분산되어 처리 순서를 보장할 수 없다.
+
+---
+
+## 설정값 요약
+
+### 프로듀서 (Spring BE - KafkaProducerConfig)
+
+```
+bootstrap.servers          = ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+key.serializer             = StringSerializer
+value.serializer           = JsonSerializer
+acks                       = all (트랜잭셔널 강제)
+enable.idempotence         = true (트랜잭셔널 강제)
+retries                    = MAX_VALUE (트랜잭셔널 강제)
+transactional.id           = channeling-be-tx-{suffix}
+retry.backoff.ms           = 1000
+delivery.timeout.ms        = 10000
+request.timeout.ms         = 5000
+compression.type           = snappy
+batch.size                 = 16384
+linger.ms                  = 5
+buffer.memory              = 33554432
+```
+
+### 컨슈머 (FastAPI LLM - kafka_config.py + base_consumer.py)
+
+```
+bootstrap.servers          = ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+group.id                   = llm-service-group
+isolation.level            = read_committed
+auto.offset.reset          = earliest
+enable.auto.commit         = true
+auto.commit.interval.ms    = 5000
+```
+
+### 토픽 (KafkaTopicConfig)
+
+```
+overview-topic-v2          partitions=1  replicas=1
+analysis-topic-v2          partitions=1  replicas=1
+```

--- a/src/main/java/channeling/be/domain/report/application/ReportKafkaMessage.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportKafkaMessage.java
@@ -1,0 +1,30 @@
+package channeling.be.domain.report.application;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class
+ReportKafkaMessage {
+
+    @JsonProperty("task_id")
+    private Long taskId;
+
+    @JsonProperty("report_id")
+    private Long reportId;
+
+    @JsonProperty("step")
+    private String step;
+
+    @JsonProperty("google_access_token")
+    private String googleAccessToken;
+
+    @JsonProperty("skip_vector_save")
+    private boolean skipVectorSave;
+}

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -27,8 +27,6 @@ import channeling.be.response.exception.handler.ChannelHandler;
 import channeling.be.response.exception.handler.ReportHandler;
 import channeling.be.response.exception.handler.TaskHandler;
 import channeling.be.response.exception.handler.VideoHandler;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,19 +34,12 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -64,10 +55,13 @@ public class ReportServiceImpl implements ReportService {
     private final ReportDeleteService reportDeleteService;
     private final ChannelRepository channelRepository;
     private final ReportLogRepository reportLogRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    //환경변수에서 FASTAPI_URL 환경변수 불러오기
-    @Value("${FASTAPI_URL:http://localhost:8000}")
-    private String baseFastApiUrl;
+    @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
+    private String overviewTopic;
+
+    @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
+    private String analysisTopic;
 
     @Override
     @Transactional(readOnly = true)
@@ -154,6 +148,7 @@ public class ReportServiceImpl implements ReportService {
     }
 
     @Override
+    @Transactional
     public ReportResDto.createReport createReport(Member member, Long videoId) {
 
         // Redis를 이용한 중복 클릭(Race Condition) 방지 (5초 락)
@@ -169,15 +164,15 @@ public class ReportServiceImpl implements ReportService {
 
             // 요청 영상 존재 여부 확인
             if (!videoRepository.existsById(videoId)) {
-                throw new VideoHandler(ErrorStatus._VIDEO_NOT_FOUND) ;
+                throw new VideoHandler(ErrorStatus._VIDEO_NOT_FOUND);
             }
 
             // 요청 영상의 주인인지 확인
             Video video = videoRepository.findByIdWithMemberId(videoId, member.getId())
                     .orElseThrow(() -> new VideoHandler(ErrorStatus._VIDEO_NOT_MEMBER));
 
-            // 멤버와 영상으로 기존에 분S석했던 리포트가 존재하는 지 조회
-            Optional<Report> optionalReport  = reportRepository.findByVideoAndMember(video.getId(), member.getId());
+            // 멤버와 영상으로 기존에 분석했던 리포트가 존재하는 지 조회
+            Optional<Report> optionalReport = reportRepository.findByVideoAndMember(video.getId(), member.getId());
 
             // 기존 리포트 존재 시 (1) 현재 생성 중 여부 확인 (2) 삭제
             optionalReport.ifPresent(report -> {
@@ -187,59 +182,45 @@ public class ReportServiceImpl implements ReportService {
 
             // redis에서 구글 토큰 가져오기 -> 2분 보다 적으면 에러 반환
             Long ttl = redisUtil.getGoogleAccessTokenExpire(member.getId());
-            log.info("리포트 분석 전, 구글 토큰 TTL (초): {}" , ttl);
+            log.info("리포트 분석 전, 구글 토큰 TTL (초): {}", ttl);
             if (ttl <= 120) {
                 throw new ReportHandler(ErrorStatus._TOKEN_EXPIRED);
             }
             String googleAccessToken = redisUtil.getGoogleAccessToken(member.getId());
 
-            // fastapi 쪽에 요청 보내기
-            Long taskId = sendPostToFastAPI(videoId, googleAccessToken);
-            // taskId로 리포트 조회
-            Report report = reportRepository.findByTaskId(taskId)
-                    .orElseThrow(() -> new ReportHandler(ErrorStatus._REPORT_NOT_CREATE));
+            // Report, Task 생성 (DB 소유권 Spring)
+            Report report = reportRepository.save(Report.builder().video(video).build());
+            Task task = taskRepository.save(Task.builder()
+                    .report(report)
+                    .overviewStatus(TaskStatus.PENDING)
+                    .analysisStatus(TaskStatus.PENDING)
+                    .ideaStatus(TaskStatus.COMPLETED)
+                    .build());
+
+            // Kafka 메시지 발행 (기존 V2 토픽 사용)
+            ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
+                    .taskId(task.getId())
+                    .reportId(report.getId())
+                    .step("overview")
+                    .googleAccessToken(googleAccessToken)
+                    .skipVectorSave(true)
+                    .build();
+
+            ReportKafkaMessage analysisMessage = ReportKafkaMessage.builder()
+                    .taskId(task.getId())
+                    .reportId(report.getId())
+                    .step("analysis")
+                    .googleAccessToken(googleAccessToken)
+                    .skipVectorSave(true)
+                    .build();
+
+            kafkaTemplate.send(overviewTopic, overviewMessage);
+            kafkaTemplate.send(analysisTopic, analysisMessage);
+            log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", report.getId(), task.getId());
 
             return new ReportResDto.createReport(report.getId(), video.getId());
         } finally {
             redisUtil.deleteData(lockKey);
-        }
-    }
-
-    private Long sendPostToFastAPI(Long videoId, String googleAccessToken) {
-//
-        // HTTP 요청 보내기
-        RestTemplate restTemplate = new RestTemplate();
-        // url 설정
-        String url = UriComponentsBuilder
-                .fromHttpUrl(baseFastApiUrl+"/reports/v2")
-                .queryParam("video_id", videoId)
-                .toUriString();
-
-        // requestbody 생성
-        Map<String, String> requestBody = new HashMap<>();
-        requestBody.put("googleAccessToken", googleAccessToken);
-
-        // 헤더 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        // 요청 생성
-        HttpEntity<Map<String, String>> request = new HttpEntity<>(requestBody, headers);
-        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
-
-        // 응답 파싱 및 반환
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode root = objectMapper.readTree(response.getBody());
-
-            JsonNode resultNode = root.get("result");
-            if (resultNode != null && resultNode.has("task_id")) {
-                return resultNode.get("task_id").asLong();
-            } else {
-                throw new IllegalStateException("응답에 id가 없습니다.");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("FastAPI 응답 파싱 실패", e);
         }
     }
 

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -191,7 +191,7 @@ public class ReportServiceImpl implements ReportService {
                     .build());
 
             // Kafka 메시지 발행 — 트랜잭션 커밋 후 전송
-            kafkaMessageProducer.sendReportMessagesAfterCommit(task.getId(), report.getId(), googleAccessToken);
+            kafkaMessageProducer.sendReportMessagesAfterCommit(task.getId(), report.getId(), googleAccessToken, member.getId());
 
             return new ReportResDto.createReport(report.getId(), video.getId());
         } finally {

--- a/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
+++ b/src/main/java/channeling/be/domain/report/application/ReportServiceImpl.java
@@ -21,6 +21,7 @@ import channeling.be.domain.video.domain.Video;
 import channeling.be.domain.video.domain.VideoCategory;
 import channeling.be.domain.video.domain.VideoType;
 import channeling.be.domain.video.domain.repository.VideoRepository;
+import channeling.be.global.infrastructure.kafka.KafkaMessageProducer;
 import channeling.be.global.infrastructure.redis.RedisUtil;
 import channeling.be.response.code.status.ErrorStatus;
 import channeling.be.response.exception.handler.ChannelHandler;
@@ -29,12 +30,10 @@ import channeling.be.response.exception.handler.TaskHandler;
 import channeling.be.response.exception.handler.VideoHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,13 +54,7 @@ public class ReportServiceImpl implements ReportService {
     private final ReportDeleteService reportDeleteService;
     private final ChannelRepository channelRepository;
     private final ReportLogRepository reportLogRepository;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
-
-    @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
-    private String overviewTopic;
-
-    @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
-    private String analysisTopic;
+    private final KafkaMessageProducer kafkaMessageProducer;
 
     @Override
     @Transactional(readOnly = true)
@@ -197,26 +190,8 @@ public class ReportServiceImpl implements ReportService {
                     .ideaStatus(TaskStatus.COMPLETED)
                     .build());
 
-            // Kafka 메시지 발행 (기존 V2 토픽 사용)
-            ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
-                    .taskId(task.getId())
-                    .reportId(report.getId())
-                    .step("overview")
-                    .googleAccessToken(googleAccessToken)
-                    .skipVectorSave(true)
-                    .build();
-
-            ReportKafkaMessage analysisMessage = ReportKafkaMessage.builder()
-                    .taskId(task.getId())
-                    .reportId(report.getId())
-                    .step("analysis")
-                    .googleAccessToken(googleAccessToken)
-                    .skipVectorSave(true)
-                    .build();
-
-            kafkaTemplate.send(overviewTopic, overviewMessage);
-            kafkaTemplate.send(analysisTopic, analysisMessage);
-            log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", report.getId(), task.getId());
+            // Kafka 메시지 발행 — 트랜잭션 커밋 후 전송
+            kafkaMessageProducer.sendReportMessagesAfterCommit(task.getId(), report.getId(), googleAccessToken);
 
             return new ReportResDto.createReport(report.getId(), video.getId());
         } finally {

--- a/src/main/java/channeling/be/domain/report/domain/ReportStep.java
+++ b/src/main/java/channeling/be/domain/report/domain/ReportStep.java
@@ -1,0 +1,19 @@
+package channeling.be.domain.report.domain;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ReportStep {
+    OVERVIEW("overview"),
+    ANALYSIS("analysis");
+
+    private final String value;
+
+    ReportStep(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/channeling/be/domain/task/domain/Task.java
+++ b/src/main/java/channeling/be/domain/task/domain/Task.java
@@ -34,4 +34,12 @@ public class Task extends BaseEntity {
     public void setReport(Report report) {
         this.report = report;
     }
+
+    public void failOverview() {
+        this.overviewStatus = TaskStatus.FAILED;
+    }
+
+    public void failAnalysis() {
+        this.analysisStatus = TaskStatus.FAILED;
+    }
 }

--- a/src/main/java/channeling/be/domain/task/domain/Task.java
+++ b/src/main/java/channeling/be/domain/task/domain/Task.java
@@ -35,11 +35,4 @@ public class Task extends BaseEntity {
         this.report = report;
     }
 
-    public void failOverview() {
-        this.overviewStatus = TaskStatus.FAILED;
-    }
-
-    public void failAnalysis() {
-        this.analysisStatus = TaskStatus.FAILED;
-    }
 }

--- a/src/main/java/channeling/be/domain/task/domain/repository/TaskRepository.java
+++ b/src/main/java/channeling/be/domain/task/domain/repository/TaskRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -34,4 +36,14 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Task t WHERE t.report.id IN :reportIds")
     void deleteAllByReportIdIn(@Param("reportIds") List<Long> reportIds);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Task t SET t.overviewStatus = 'FAILED' WHERE t.id = :id")
+    void failOverviewStatus(@Param("id") Long id);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Task t SET t.analysisStatus = 'FAILED' WHERE t.id = :id")
+    void failAnalysisStatus(@Param("id") Long id);
 }

--- a/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
+++ b/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
@@ -1,0 +1,37 @@
+package channeling.be.global.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        // FastAPI JSON 역직렬화 호환을 위해 Spring 타입 헤더 비활성화
+        config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
+++ b/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
@@ -30,12 +30,11 @@ public class KafkaProducerConfig {
         // ── acks 설정 ───────────────────────────────────────────
         config.put(ProducerConfig.ACKS_CONFIG, "all");                                   // 리더 + 모든 ISR 저장 확인 후 ack
 
-        // ── retries 설정 ────────────────────────────────────────
-        config.put(ProducerConfig.RETRIES_CONFIG, 3);                                    // 전송 실패 시 최대 3회 재시도
+        // ── retries / timeout 설정 ─────────────────────────────────
+        // 트랜잭션 프로듀서를 사용하므로, 재시도 횟수 제거, 멱등성 기본값 true 설정
         config.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 1000);                        // 재시도 간격 1초
-        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 120000);                   // send()부터 최종 ack까지 최대 2분
-        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);                     // 단일 전송 요청 타임아웃 30초
-        config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);                      // 중복 방지 + 재시도 시 순서 보장
+        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 10000);                    // send()부터 최종 ack까지 최대 10초 (빠른 실패)
+        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 5000);                      // 단일 전송 요청 타임아웃 5초
 
         // ── compression 설정 ────────────────────────────────────
         config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");                    // 배치 단위 압축 (속도/압축률 균형)
@@ -45,7 +44,9 @@ public class KafkaProducerConfig {
         config.put(ProducerConfig.LINGER_MS_CONFIG, 5);                                  // 배치 미달 시 최대 5ms 대기 후 전송
         config.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);                       // 미전송 메시지 대기 버퍼 32MB
 
-        return new DefaultKafkaProducerFactory<>(config);
+        DefaultKafkaProducerFactory<String, Object> factory = new DefaultKafkaProducerFactory<>(config);
+        factory.setTransactionIdPrefix("channeling-be-tx-");                             // 트랜잭션 프로듀서 활성화 (인스턴스별 고유 suffix 자동 부여)
+        return factory;
     }
 
     @Bean

--- a/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
+++ b/src/main/java/channeling/be/global/config/KafkaProducerConfig.java
@@ -12,7 +12,6 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
-
 @Configuration
 public class KafkaProducerConfig {
 
@@ -22,11 +21,30 @@ public class KafkaProducerConfig {
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> config = new HashMap<>();
-        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        // FastAPI JSON 역직렬화 호환을 위해 Spring 타입 헤더 비활성화
-        config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+
+        // ── 기본 설정 ──────────────────────────────────────────
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);           // Kafka 브로커 초기 접속 주소
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);  // Key를 String → byte[] 변환
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);  // Value를 Object → JSON byte[] 변환
+
+        // ── acks 설정 ───────────────────────────────────────────
+        config.put(ProducerConfig.ACKS_CONFIG, "all");                                   // 리더 + 모든 ISR 저장 확인 후 ack
+
+        // ── retries 설정 ────────────────────────────────────────
+        config.put(ProducerConfig.RETRIES_CONFIG, 3);                                    // 전송 실패 시 최대 3회 재시도
+        config.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 1000);                        // 재시도 간격 1초
+        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 120000);                   // send()부터 최종 ack까지 최대 2분
+        config.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);                     // 단일 전송 요청 타임아웃 30초
+        config.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);                      // 중복 방지 + 재시도 시 순서 보장
+
+        // ── compression 설정 ────────────────────────────────────
+        config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");                    // 배치 단위 압축 (속도/압축률 균형)
+
+        // ── 배치/버퍼 설정 (선택) ────────────────────────────────
+        config.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);                             // 파티션당 배치 크기 16KB
+        config.put(ProducerConfig.LINGER_MS_CONFIG, 5);                                  // 배치 미달 시 최대 5ms 대기 후 전송
+        config.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);                       // 미전송 메시지 대기 버퍼 32MB
+
         return new DefaultKafkaProducerFactory<>(config);
     }
 

--- a/src/main/java/channeling/be/global/config/KafkaTopicConfig.java
+++ b/src/main/java/channeling/be/global/config/KafkaTopicConfig.java
@@ -1,0 +1,39 @@
+package channeling.be.global.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Value("${spring.kafka.topic.overview}")
+    private String overviewTopic;
+
+    @Value("${spring.kafka.topic.analysis}")
+    private String analysisTopic;
+
+    @Value("${spring.kafka.topic.partitions}")
+    private int partitions;
+
+    @Value("${spring.kafka.topic.replicas}")
+    private int replicas;
+
+    @Bean
+    public NewTopic overviewTopic() {
+        return TopicBuilder.name(overviewTopic)
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic analysisTopic() {
+        return TopicBuilder.name(analysisTopic)
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
+}

--- a/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
@@ -1,0 +1,17 @@
+package channeling.be.global.infrastructure.kafka;
+
+import channeling.be.global.infrastructure.kafka.dto.ReportKafkaEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageProducer {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void sendReportMessagesAfterCommit(Long taskId, Long reportId, String googleAccessToken) {
+        eventPublisher.publishEvent(new ReportKafkaEvent(taskId, reportId, googleAccessToken));
+    }
+}

--- a/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/KafkaMessageProducer.java
@@ -11,7 +11,7 @@ public class KafkaMessageProducer {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public void sendReportMessagesAfterCommit(Long taskId, Long reportId, String googleAccessToken) {
-        eventPublisher.publishEvent(new ReportKafkaEvent(taskId, reportId, googleAccessToken));
+    public void sendReportMessagesAfterCommit(Long taskId, Long reportId, String googleAccessToken, Long userId) {
+        eventPublisher.publishEvent(new ReportKafkaEvent(taskId, reportId, googleAccessToken, userId));
     }
 }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -4,6 +4,7 @@ import channeling.be.domain.report.domain.ReportStep;
 import channeling.be.domain.task.domain.repository.TaskRepository;
 import channeling.be.global.infrastructure.kafka.dto.ReportKafkaEvent;
 import channeling.be.global.infrastructure.kafka.dto.ReportKafkaMessage;
+import channeling.be.global.infrastructure.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +20,7 @@ public class ReportKafkaEventListener {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final TaskRepository taskRepository;
+    private final RedisUtil redisUtil;
 
     @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
     private String overviewTopic;
@@ -44,22 +46,24 @@ public class ReportKafkaEventListener {
                 .skipVectorSave(true)
                 .build();
 
-        sendWithFailureHandling(overviewTopic, overviewMessage, event.taskId(), ReportStep.OVERVIEW);
-        sendWithFailureHandling(analysisTopic, analysisMessage, event.taskId(), ReportStep.ANALYSIS);
-        log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
+        sendWithFailureHandling(overviewTopic, overviewMessage, event.taskId(), ReportStep.OVERVIEW, event.userId());
+        sendWithFailureHandling(analysisTopic, analysisMessage, event.taskId(), ReportStep.ANALYSIS, event.userId());
+        log.info("Kafka 메시지 발행 요청 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
     }
 
-    private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step) {
+    private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step, Long userId) {
         kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
             if (ex != null) {
-                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}, error: {}", topic, taskId, step, ex.getMessage());
-                taskRepository.findById(taskId).ifPresent(task -> {
+                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}", topic, taskId, step, ex);
+                try {
                     switch (step) {
-                        case OVERVIEW -> task.failOverview();
-                        case ANALYSIS -> task.failAnalysis();
+                        case OVERVIEW -> taskRepository.failOverviewStatus(taskId);
+                        case ANALYSIS -> taskRepository.failAnalysisStatus(taskId);
                     }
-                    taskRepository.save(task);
-                });
+                    redisUtil.publishFailure(userId, step.getValue());
+                } catch (Exception e) {
+                    log.error("Kafka 전송 실패 후처리 중 오류 - taskId: {}, step: {}", taskId, step, e);
+                }
             }
         });
     }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -48,20 +48,17 @@ public class ReportKafkaEventListener {
                 .skipVectorSave(true)
                 .build();
 
-        sendWithFailureHandling(overviewTopic, overviewMessage, event.taskId(), ReportStep.OVERVIEW, event.userId());
-        sendWithFailureHandling(analysisTopic, analysisMessage, event.taskId(), ReportStep.ANALYSIS, event.userId());
-        log.info("Kafka 메시지 발행 요청 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
-    }
-
-    private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step, Long userId) {
         try {
-            kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
-                if (ex != null) {
-                    handleFailure(topic, taskId, step, userId, ex);
-                }
+            kafkaTemplate.executeInTransaction(ops -> {
+                ops.send(overviewTopic, overviewMessage);
+                ops.send(analysisTopic, analysisMessage);
+                return null;
             });
+            log.info("Kafka 트랜잭션 메시지 발행 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
         } catch (Exception ex) {
-            handleFailure(topic, taskId, step, userId, ex);
+            log.error("Kafka 트랜잭션 발행 실패 - reportId: {}, taskId: {}", event.reportId(), event.taskId(), ex);
+            handleFailure(overviewTopic, event.taskId(), ReportStep.OVERVIEW, event.userId(), ex);
+            handleFailure(analysisTopic, event.taskId(), ReportStep.ANALYSIS, event.userId(), ex);
         }
     }
 

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -28,6 +29,7 @@ public class ReportKafkaEventListener {
     @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
     private String analysisTopic;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReportKafkaEvent(ReportKafkaEvent event) {
         ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
@@ -52,19 +54,27 @@ public class ReportKafkaEventListener {
     }
 
     private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step, Long userId) {
-        kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
-            if (ex != null) {
-                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}", topic, taskId, step, ex);
-                try {
-                    switch (step) {
-                        case OVERVIEW -> taskRepository.failOverviewStatus(taskId);
-                        case ANALYSIS -> taskRepository.failAnalysisStatus(taskId);
-                    }
-                    redisUtil.publishFailure(userId, step.getValue());
-                } catch (Exception e) {
-                    log.error("Kafka 전송 실패 후처리 중 오류 - taskId: {}, step: {}", taskId, step, e);
+        try {
+            kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
+                if (ex != null) {
+                    handleFailure(topic, taskId, step, userId, ex);
                 }
+            });
+        } catch (Exception ex) {
+            handleFailure(topic, taskId, step, userId, ex);
+        }
+    }
+
+    private void handleFailure(String topic, Long taskId, ReportStep step, Long userId, Throwable ex) {
+        log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}", topic, taskId, step, ex);
+        try {
+            switch (step) {
+                case OVERVIEW -> taskRepository.failOverviewStatus(taskId);
+                case ANALYSIS -> taskRepository.failAnalysisStatus(taskId);
             }
-        });
+            redisUtil.publishFailure(userId, step.getValue());
+        } catch (Exception e) {
+            log.error("Kafka 전송 실패 후처리 중 오류 - taskId: {}, step: {}", taskId, step, e);
+        }
     }
 }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -1,0 +1,66 @@
+package channeling.be.global.infrastructure.kafka;
+
+import channeling.be.domain.report.domain.ReportStep;
+import channeling.be.domain.task.domain.repository.TaskRepository;
+import channeling.be.global.infrastructure.kafka.dto.ReportKafkaEvent;
+import channeling.be.global.infrastructure.kafka.dto.ReportKafkaMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReportKafkaEventListener {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final TaskRepository taskRepository;
+
+    @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
+    private String overviewTopic;
+
+    @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
+    private String analysisTopic;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReportKafkaEvent(ReportKafkaEvent event) {
+        ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
+                .taskId(event.taskId())
+                .reportId(event.reportId())
+                .step(ReportStep.OVERVIEW)
+                .googleAccessToken(event.googleAccessToken())
+                .skipVectorSave(true)
+                .build();
+
+        ReportKafkaMessage analysisMessage = ReportKafkaMessage.builder()
+                .taskId(event.taskId())
+                .reportId(event.reportId())
+                .step(ReportStep.ANALYSIS)
+                .googleAccessToken(event.googleAccessToken())
+                .skipVectorSave(true)
+                .build();
+
+        sendWithFailureHandling(overviewTopic, overviewMessage, event.taskId(), ReportStep.OVERVIEW);
+        sendWithFailureHandling(analysisTopic, analysisMessage, event.taskId(), ReportStep.ANALYSIS);
+        log.info("Kafka 메시지 발행 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
+    }
+
+    private void sendWithFailureHandling(String topic, ReportKafkaMessage message, Long taskId, ReportStep step) {
+        kafkaTemplate.send(topic, message).whenComplete((result, ex) -> {
+            if (ex != null) {
+                log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}, error: {}", topic, taskId, step, ex.getMessage());
+                taskRepository.findById(taskId).ifPresent(task -> {
+                    switch (step) {
+                        case OVERVIEW -> task.failOverview();
+                        case ANALYSIS -> task.failAnalysis();
+                    }
+                    taskRepository.save(task);
+                });
+            }
+        });
+    }
+}

--- a/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/ReportKafkaEventListener.java
@@ -7,7 +7,7 @@ import channeling.be.global.infrastructure.kafka.dto.ReportKafkaMessage;
 import channeling.be.global.infrastructure.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -22,48 +22,37 @@ public class ReportKafkaEventListener {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final TaskRepository taskRepository;
     private final RedisUtil redisUtil;
-
-    @Value("${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}")
-    private String overviewTopic;
-
-    @Value("${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}")
-    private String analysisTopic;
+    private final NewTopic overviewTopic;
+    private final NewTopic analysisTopic;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReportKafkaEvent(ReportKafkaEvent event) {
-        ReportKafkaMessage overviewMessage = ReportKafkaMessage.builder()
-                .taskId(event.taskId())
-                .reportId(event.reportId())
-                .step(ReportStep.OVERVIEW)
-                .googleAccessToken(event.googleAccessToken())
-                .skipVectorSave(true)
-                .build();
-
-        ReportKafkaMessage analysisMessage = ReportKafkaMessage.builder()
-                .taskId(event.taskId())
-                .reportId(event.reportId())
-                .step(ReportStep.ANALYSIS)
-                .googleAccessToken(event.googleAccessToken())
-                .skipVectorSave(true)
-                .build();
-
         try {
             kafkaTemplate.executeInTransaction(ops -> {
-                ops.send(overviewTopic, overviewMessage);
-                ops.send(analysisTopic, analysisMessage);
+                ops.send(overviewTopic.name(), buildMessage(event, ReportStep.OVERVIEW));
+                ops.send(analysisTopic.name(), buildMessage(event, ReportStep.ANALYSIS));
                 return null;
             });
             log.info("Kafka 트랜잭션 메시지 발행 완료 - reportId: {}, taskId: {}", event.reportId(), event.taskId());
         } catch (Exception ex) {
             log.error("Kafka 트랜잭션 발행 실패 - reportId: {}, taskId: {}", event.reportId(), event.taskId(), ex);
-            handleFailure(overviewTopic, event.taskId(), ReportStep.OVERVIEW, event.userId(), ex);
-            handleFailure(analysisTopic, event.taskId(), ReportStep.ANALYSIS, event.userId(), ex);
+            handleFailure(event.taskId(), ReportStep.OVERVIEW, event.userId());
+            handleFailure(event.taskId(), ReportStep.ANALYSIS, event.userId());
         }
     }
 
-    private void handleFailure(String topic, Long taskId, ReportStep step, Long userId, Throwable ex) {
-        log.error("Kafka 전송 실패 - topic: {}, taskId: {}, step: {}", topic, taskId, step, ex);
+    private ReportKafkaMessage buildMessage(ReportKafkaEvent event, ReportStep step) {
+        return ReportKafkaMessage.builder()
+                .taskId(event.taskId())
+                .reportId(event.reportId())
+                .step(step)
+                .googleAccessToken(event.googleAccessToken())
+                .skipVectorSave(true)
+                .build();
+    }
+
+    private void handleFailure(Long taskId, ReportStep step, Long userId) {
         try {
             switch (step) {
                 case OVERVIEW -> taskRepository.failOverviewStatus(taskId);

--- a/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
@@ -1,0 +1,8 @@
+package channeling.be.global.infrastructure.kafka.dto;
+
+public record ReportKafkaEvent(
+        Long taskId,
+        Long reportId,
+        String googleAccessToken
+) {
+}

--- a/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaEvent.java
@@ -3,6 +3,7 @@ package channeling.be.global.infrastructure.kafka.dto;
 public record ReportKafkaEvent(
         Long taskId,
         Long reportId,
-        String googleAccessToken
+        String googleAccessToken,
+        Long userId
 ) {
 }

--- a/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaMessage.java
+++ b/src/main/java/channeling/be/global/infrastructure/kafka/dto/ReportKafkaMessage.java
@@ -1,5 +1,6 @@
-package channeling.be.domain.report.application;
+package channeling.be.global.infrastructure.kafka.dto;
 
+import channeling.be.domain.report.domain.ReportStep;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,8 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class
-ReportKafkaMessage {
+public class ReportKafkaMessage {
 
     @JsonProperty("task_id")
     private Long taskId;
@@ -20,7 +20,7 @@ ReportKafkaMessage {
     private Long reportId;
 
     @JsonProperty("step")
-    private String step;
+    private ReportStep step;
 
     @JsonProperty("google_access_token")
     private String googleAccessToken;

--- a/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
+++ b/src/main/java/channeling/be/global/infrastructure/redis/RedisUtil.java
@@ -1,12 +1,15 @@
 package channeling.be.global.infrastructure.redis;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -14,10 +17,12 @@ import java.util.concurrent.TimeUnit;
  *    - 문자열(String) 타입 전용 StringRedisTemplate을 주입받아 사용
  *    - 기본 CRUD + 만료시간 설정 기능 제공
  */
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class RedisUtil {
     private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
 
     /** redis에 저장하는 구글 엑세스의 지속 시간 **/
     @Value("${jwt.google.access.expiration}")
@@ -142,5 +147,24 @@ public class RedisUtil {
                 String.valueOf(1),
                 Duration.ofSeconds(accessExpiration)
         );
+    }
+
+    // ── Redis Pub/Sub ──────────────────────────────────
+
+    private static final String COMPLETE_CHANNEL = "complete";
+
+    public void publishFailure(Long userId, String step) {
+        try {
+            String innerMessage = objectMapper.writeValueAsString(
+                    Map.of("status", "fail", "step", step)
+            );
+            String payload = objectMapper.writeValueAsString(
+                    Map.of("userId", String.valueOf(userId), "message", innerMessage)
+            );
+            stringRedisTemplate.convertAndSend(COMPLETE_CHANNEL, payload);
+            log.info("Redis 실패 알림 발행 - userId: {}, step: {}", userId, step);
+        } catch (Exception e) {
+            log.error("Redis Publish 실패 - userId: {}, step: {}", userId, step, e);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,5 @@ spring:
     name: channeling-be
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:db,s3,oauth,jwt}
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,8 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:db,s3,oauth,jwt}
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    topic:
+      overview: ${KAFKA_OVERVIEW_TOPIC:overview-topic-v2}
+      analysis: ${KAFKA_ANALYSIS_TOPIC:analysis-topic-v2}
+      partitions: ${KAFKA_TOPIC_PARTITIONS:1}
+      replicas: ${KAFKA_TOPIC_REPLICAS:1}


### PR DESCRIPTION
## PR 제목
[Feat/Fix/Refactor/Docs/Chore 등]: 간결하게 변경 내용을 요약해주세요. (예: Feat: 사용자 로그인 기능 구현)

카프카 프로듀서 설정 수정 및 트랜잭션 프로듀서 적용

## 📚 변경 내용
구체적으로 어떤 변경 사항이 있는지, 왜 이러한 변경이 필요한지 설명해주세요.
(예: 사용자 회원가입 시 이메일 중복 확인 로직 추가. 기존 로직에서 누락된 부분 발견하여 수정.)

24주차 회의록 참고

- 트랜잭션 프로듀서 사용에 따라 RETRIES_CONFIG 기본값(true) 설정
   > 단, DELIVERY_TIMEOUT_MS_CONFIG, REQUEST_TIMEOUT_MS_CONFIG 단축 (빠른 실패 처리)
- ReportKafkaEventListener에서 토픽들을 단일 트랜잭션으로 묶어 원자성 보장
   > KafkaProducerConfig에 트랜잭션 ID 프리픽스를 설정하여 트랜잭션 프로듀서 활성화
   > 트랜잭션 실패 시 관련 메시지 모두 롤백하여 데이터 일관성 유지
- LLM isolation.level 설정 수정 (⭐️)
   > FastStream 기본값이 read_uncommitted이므로 변경
   > 커밋 전 메시지는 읽지 않도록! (원자성은 브로커 레벨에서 커밋 마킹으로 구현됨 -> 커밋 전 메시지들이 브로커에 써져 있음)

## 🔗 관련 이슈 (선택 사항)
해당 PR이 해결하는 이슈 또는 관련 있는 이슈가 있다면 링크를 걸어주세요.
(예: #123, ABC-456)

- #300 
- https://github.com/channeling-ai/LLM/issues/193

## 💬 기타 (선택 사항)
리뷰어에게 전달하고 싶은 추가 정보나 궁금한 점이 있다면 작성해주세요.

1. A파트(BE+LLM) 정리 문서 추가 (/docs, 리팩토링 완료 후 제거)
2. 멱등성과 별개로 중복 처리 로직 도입에 대해서 리팩토링 완료 이후 고려해보면 좋을 거 같습니다
BE->LLM 컨슈머에서 중복 메시지가 동작하면 호출 비용 낭비
```
컨슈머 재처리 중복은 전혀 다른 지점에서 발생합니다. 카프카는 기본적으로 at-least-once delivery이기 때문에, 
컨슈머가 메시지를 poll해서 처리한 뒤 오프셋을 커밋하기 전에 죽으면, 재시작 시 같은 메시지를 다시 가져옵니다. 
이건 카프카 입장에서는 중복이 아니라 정상 동작입니다.

대부분의 경우 멱등한 처리 설계가 가장 현실적입니다. 
INSERT를 INSERT ... ON CONFLICT DO NOTHING (UPSERT)으로 바꾸거나, 
상태 업데이트가 여러 번 와도 결과가 같게 만드는 식으로요. 복잡한 중복 체크 로직 없이도 해결됩니다.
중복 체크 테이블 방식은 확실하지만 처리마다 조회 비용이 생기고, 아웃박스 패턴은 가장 강력하지만 구현이 꽤 복잡합니다.
요약하면, read_committed는 반드시 설정해야 하지만, 컨슈머 재처리에 대한 멱등성은 앱 레벨에서 따로 고려해야 합니다.
```